### PR TITLE
Make bot endpoint optional during creation

### DIFF
--- a/src/apps/home.ts
+++ b/src/apps/home.ts
@@ -61,7 +61,11 @@ export async function showAppHome(appSummary: AppSummary, token: string): Promis
       console.log(`${pc.dim("Description:")} ${appDetails.shortDescription}`);
     }
     if (bot) {
-      console.log(`${pc.dim("Endpoint:")} ${bot.messagingEndpoint || pc.dim("(not set)")}`);
+      if (bot.messagingEndpoint) {
+        console.log(`${pc.dim("Endpoint:")} ${bot.messagingEndpoint}`);
+      } else {
+        console.log(`${pc.dim("Endpoint:")} ${pc.yellow("⚠ Not set — use \"Edit endpoint\" to configure")}`);
+      }
     }
 
     const action = await select({

--- a/src/commands/app/create.ts
+++ b/src/commands/app/create.ts
@@ -35,7 +35,7 @@ interface CreateOptions {
 export const appCreateCommand = new Command("create")
   .description("Create a new Teams app with bot")
   .option("-n, --name <name>", "App/bot name")
-  .option("-e, --endpoint <url>", "Bot messaging endpoint URL")
+  .option("-e, --endpoint <url>", "[OPTIONAL] Bot messaging endpoint URL")
   .option("-m, --manifest <path>", "[OPTIONAL] Path to manifest.json")
   .option("-p, --package <path>", "[OPTIONAL] Path to app package zip")
   .option("--env <path>", "[OPTIONAL] Path to .env file to write credentials")
@@ -65,10 +65,10 @@ export const appCreateCommand = new Command("create")
       options.name ??
       (options.package ? undefined : await input({ message: "App name:" }));
 
-    // Get endpoint
+    // Get endpoint (optional - can be set later)
     const endpoint =
       options.endpoint ??
-      (await input({ message: "Bot messaging endpoint URL:" }));
+      ((await input({ message: "Bot messaging endpoint URL (leave empty to skip):" })) || undefined);
 
     // Get env path
     const envPath =
@@ -174,7 +174,7 @@ export const appCreateCommand = new Command("create")
       await registerBot(tdpToken, {
         botId: clientId,
         name: name ?? "Bot",
-        endpoint,
+        endpoint: endpoint ?? "",
       });
       spinner.success({ text: "Registered bot" });
 
@@ -185,7 +185,7 @@ export const appCreateCommand = new Command("create")
           BOT_ID: clientId,
           BOT_PASSWORD: secretText,
           TEAMS_APP_ID: teamsAppId,
-          BOT_ENDPOINT: endpoint,
+          ...(endpoint ? { BOT_ENDPOINT: endpoint } : {}),
         });
         spinner.success({ text: `Credentials written to ${envPath}` });
 
@@ -197,7 +197,9 @@ export const appCreateCommand = new Command("create")
         logger.info(`\n${pc.dim("Client ID:")} ${clientId}`);
         logger.info(`${pc.dim("Client Secret:")} ${secretText}`);
         logger.info(`${pc.dim("Teams App ID:")} ${teamsAppId}`);
-        logger.info(`${pc.dim("Endpoint:")} ${endpoint}`);
+        if (endpoint) {
+          logger.info(`${pc.dim("Endpoint:")} ${endpoint}`);
+        }
 
         logger.warn("Save the client secret - it won't be shown again!");
       }


### PR DESCRIPTION
## Summary
- Bot messaging endpoint is now optional during `teams app create` — users can leave it empty and set it later
- When viewing bot details without an endpoint, a yellow warning is shown prompting the user to configure it via "Edit endpoint"
- `.env` output and terminal display skip the endpoint field when not provided

## Test plan
- [ ] Run `teams app create` and leave endpoint empty — verify bot is created without error
- [ ] Run `teams app create -e https://example.com` — verify endpoint is still accepted
- [ ] Open an app with a bot that has no endpoint — verify yellow warning appears
- [ ] Open an app with a bot that has an endpoint — verify it displays normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)