### PR TITLE
Add CI build check workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,24 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - run: pnpm install
+
+      - run: pnpm build


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/ci.yml` that runs `pnpm build` on every PR and push to main
- Catches TypeScript compilation errors before merge

## Test plan
- [ ] This PR itself should trigger the workflow — check the Actions tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)