### PR TITLE
Fix build to clean dist before compiling

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,6 +52,10 @@ Always run `npm run build` after changes — the CLI runs from `dist/`, not sour
 
 Use Commander's built-in features for global flags and hooks. Don't manually parse `process.argv` — use `.option()` on the program and access via `optsWithGlobals()` in `preAction` hooks.
 
+## Pre-PR Validation
+
+Before creating a PR, always run the agentic tests defined in `agentic-tests.md`. These are basic smoke tests (setup/act/assert) that verify the CLI works end-to-end. Run `pnpm build` first, then execute each test scenario via `node dist/index.js <command>` (not the global `teams` command) and confirm expected output.
+
 # Architecture Decisions
 
 ## AAD App Creation — Use TDP, Not Graph API

--- a/agentic-tests.md
+++ b/agentic-tests.md
@@ -1,0 +1,21 @@
+# Agentic Tests
+
+Smoke tests to run before creating a PR. Each test follows setup/act/assert.
+
+Always run from the local build, not the global `teams` command:
+
+```
+node dist/index.js <command>
+```
+
+## 1. `login` prompts or confirms login
+
+**Setup:** `pnpm build`
+**Act:** Run `node dist/index.js login`
+**Assert:** Either prompts for login (device code flow) OR shows that you're already logged in.
+
+## 2. `apps` lists apps
+
+**Setup:** `pnpm build` and be logged in
+**Act:** Run `node dist/index.js apps`
+**Assert:** Outputs a list of apps (may be empty list, but should not error).

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   },
   "scripts": {
     "dev": "tsx src/index.ts",
-    "build": "tsc",
+    "build": "rm -rf dist && tsc",
     "start": "node dist/index.js",
     "test": "vitest run",
     "test:watch": "vitest",


### PR DESCRIPTION
## Summary
- `tsc` doesn't delete old output files, so deleted source files (like `src/utils/http.ts`) left stale artifacts in `dist/`. This caused a crash after `teams self-update` because the published tarball included `dist/utils/http.js` with a bare `require()` in an ESM package.
- Changed build script to `rm -rf dist && tsc` to always start from a clean `dist/`
- Added agentic smoke tests (`agentic-tests.md`) and pre-PR validation instructions to `CLAUDE.md`

## Test plan
- [x] `pnpm build` succeeds with clean dist
- [x] `node dist/index.js --version` prints version
- [x] `node dist/index.js login` prompts device code flow (no crash)
- [x] `node dist/index.js apps` returns "Not logged in" message (no crash)

🤖 Generated with [Claude Code](https://claude.com/claude-code)