### PR TITLE
Fix ESM require crash in http.ts

### DIFF
--- a/src/utils/http.ts
+++ b/src/utils/http.ts
@@ -1,3 +1,6 @@
+import { createRequire } from "node:module";
+
+const require = createRequire(import.meta.url);
 const { version } = require("../../package.json");
 const USER_AGENT = `teams-cli/${version}`;
 


### PR DESCRIPTION
## Summary
- `src/utils/http.ts` used a bare `require()` which crashes in ESM modules (`"type": "module"` in package.json)
- Replaced with `createRequire(import.meta.url)`, matching `index.ts` and `update-check.ts`
- This is the root cause of the CLI crash after `teams self-update`

## Test plan
- [x] `pnpm build` succeeds
- [x] `node dist/index.js --version` prints version
- [x] `node dist/index.js login` prompts device code flow (no crash)
- [x] `node dist/index.js apps` returns "Not logged in" message (no crash)

🤖 Generated with [Claude Code](https://claude.com/claude-code)