### PR TITLE
Remove commit hash from version string

### DIFF
--- a/version.json
+++ b/version.json
@@ -1,5 +1,9 @@
 {
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/main/src/NerdBank.GitVersioning/version.schema.json",
   "version": "1.0",
-  "pathFilters": ["./src"]
+  "pathFilters": ["./src"],
+  "publicReleaseRefSpec": [
+    "^refs/heads/main$",
+    "^refs/tags/v\\d+\\.\\d+"
+  ]
 }


### PR DESCRIPTION
## Summary
- Adds `publicReleaseRefSpec` to `version.json` so builds from `main` and version tags (e.g., `v1.0`) produce clean semver without the `-gabc1234` commit hash suffix

## Test plan
- [x] Builds on `main` should produce versions like `1.0.42` instead of `1.0.42-gabc1234`
- [x] Builds on feature branches still include the hash (useful for dev builds)

🤖 Generated with [Claude Code](https://claude.com/claude-code)