### PR TITLE
fix: forward appId through user-auth menu chain

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -107,6 +107,10 @@ When adding or renaming commands, menu items, or features, update the correspond
 - `docs/commands/index.md` — command tree overview
 - `docs/index.md` — landing page feature descriptions
 
+## Testing
+
+All new tests must follow a **red/green cycle**: write the test first, verify it fails against the broken code (red), then apply the fix and verify it passes (green). This ensures tests actually catch the bug they're designed for.
+
 ## Pre-PR Validation
 
 Before creating a PR:

--- a/src/commands/app/actions.ts
+++ b/src/commands/app/actions.ts
@@ -65,7 +65,7 @@ export async function showAppActions(app: AppSummary, token: string): Promise<vo
       }
     } else if (action === "user-auth") {
       try {
-        await userAuthCommand.parseAsync([], { from: "user" });
+        await userAuthCommand.parseAsync([app.teamsAppId], { from: "user" });
       } catch (error) {
         if (error instanceof Error && error.name === "ExitPromptError") continue;
         logger.error(pc.red(error instanceof Error ? error.message : "Unknown error"));

--- a/src/commands/app/user-auth/index.ts
+++ b/src/commands/app/user-auth/index.ts
@@ -6,11 +6,14 @@ import { isInteractive } from "../../../utils/interactive.js";
 
 export const userAuthCommand = new Command("user-auth")
   .description("Manage user authentication")
-  .action(async function (this: Command) {
+  .argument("[appId]", "App ID")
+  .action(async function (this: Command, appId?: string) {
     if (!isInteractive()) {
       this.help();
       return;
     }
+
+    const args = appId ? [appId] : [];
 
     while (true) {
       try {
@@ -26,9 +29,9 @@ export const userAuthCommand = new Command("user-auth")
         if (action === "back") return;
 
         if (action === "oauth") {
-          await oauthCommand.parseAsync([], { from: "user" });
+          await oauthCommand.parseAsync(args, { from: "user" });
         } else if (action === "sso") {
-          await ssoCommand.parseAsync([], { from: "user" });
+          await ssoCommand.parseAsync(args, { from: "user" });
         }
       } catch (error) {
         if (error instanceof Error && error.name === "ExitPromptError") return;

--- a/src/commands/app/user-auth/oauth/index.ts
+++ b/src/commands/app/user-auth/oauth/index.ts
@@ -7,11 +7,14 @@ import { isInteractive } from "../../../../utils/interactive.js";
 
 export const oauthCommand = new Command("oauth")
   .description("Manage OAuth connections (Azure bots only)")
-  .action(async function (this: Command) {
+  .argument("[appId]", "App ID")
+  .action(async function (this: Command, appId?: string) {
     if (!isInteractive()) {
       this.help();
       return;
     }
+
+    const args = appId ? [appId] : [];
 
     while (true) {
       try {
@@ -28,11 +31,11 @@ export const oauthCommand = new Command("oauth")
         if (action === "back") return;
 
         if (action === "add") {
-          await oauthAddCommand.parseAsync([], { from: "user" });
+          await oauthAddCommand.parseAsync(args, { from: "user" });
         } else if (action === "list") {
-          await oauthListCommand.parseAsync([], { from: "user" });
+          await oauthListCommand.parseAsync(args, { from: "user" });
         } else if (action === "remove") {
-          await oauthRemoveCommand.parseAsync([], { from: "user" });
+          await oauthRemoveCommand.parseAsync(args, { from: "user" });
         }
       } catch (error) {
         if (error instanceof Error && error.name === "ExitPromptError") return;

--- a/src/commands/app/user-auth/sso/index.ts
+++ b/src/commands/app/user-auth/sso/index.ts
@@ -21,7 +21,8 @@ interface AuthSetting {
 
 export const ssoCommand = new Command("sso")
   .description("Manage SSO configuration (Azure bots only)")
-  .action(async function (this: Command) {
+  .argument("[appId]", "App ID")
+  .action(async function (this: Command, appIdArg?: string) {
     if (!isInteractive()) {
       this.help();
       return;
@@ -29,7 +30,7 @@ export const ssoCommand = new Command("sso")
 
     let azureBotContext: Awaited<ReturnType<typeof requireAzureBot>>;
     try {
-      azureBotContext = await requireAzureBot();
+      azureBotContext = await requireAzureBot(appIdArg);
     } catch (error) {
       if (error instanceof Error && error.name === "ExitPromptError") return;
       throw error;

--- a/tests/menu-loop.test.ts
+++ b/tests/menu-loop.test.ts
@@ -132,6 +132,114 @@ describe("user-auth menu loop", () => {
   });
 });
 
+describe("user-auth forwards appId", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    setupMocks();
+  });
+
+  it("passes appId to oauth subcommand", async () => {
+    const { select } = await import("@inquirer/prompts");
+    const mockedSelect = vi.mocked(select);
+    mockedSelect
+      .mockResolvedValueOnce("oauth" as never)
+      .mockResolvedValueOnce("back" as never);
+
+    const { userAuthCommand } = await import(
+      "../src/commands/app/user-auth/index.js"
+    );
+
+    const oauthParseSpy = vi.fn().mockResolvedValue(undefined);
+    const oauthSub = userAuthCommand.commands.find(
+      (c: Command) => c.name() === "oauth"
+    );
+    if (oauthSub) oauthSub.parseAsync = oauthParseSpy;
+
+    await userAuthCommand.parseAsync(["my-app-id"], { from: "user" });
+
+    expect(oauthParseSpy).toHaveBeenCalledWith(["my-app-id"], { from: "user" });
+  });
+
+  it("passes appId to sso subcommand", async () => {
+    const { select } = await import("@inquirer/prompts");
+    const mockedSelect = vi.mocked(select);
+    mockedSelect
+      .mockResolvedValueOnce("sso" as never)
+      .mockResolvedValueOnce("back" as never);
+
+    const { userAuthCommand } = await import(
+      "../src/commands/app/user-auth/index.js"
+    );
+
+    const ssoParseSpy = vi.fn().mockResolvedValue(undefined);
+    const ssoSub = userAuthCommand.commands.find(
+      (c: Command) => c.name() === "sso"
+    );
+    if (ssoSub) ssoSub.parseAsync = ssoParseSpy;
+
+    await userAuthCommand.parseAsync(["my-app-id"], { from: "user" });
+
+    expect(ssoParseSpy).toHaveBeenCalledWith(["my-app-id"], { from: "user" });
+  });
+});
+
+describe("oauth forwards appId", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    setupMocks();
+  });
+
+  it("passes appId to add subcommand", async () => {
+    const { select } = await import("@inquirer/prompts");
+    const mockedSelect = vi.mocked(select);
+    mockedSelect
+      .mockResolvedValueOnce("add" as never)
+      .mockResolvedValueOnce("back" as never);
+
+    const { oauthCommand } = await import(
+      "../src/commands/app/user-auth/oauth/index.js"
+    );
+
+    const addParseSpy = vi.fn().mockResolvedValue(undefined);
+    const addSub = oauthCommand.commands.find(
+      (c: Command) => c.name() === "add"
+    );
+    if (addSub) addSub.parseAsync = addParseSpy;
+
+    await oauthCommand.parseAsync(["my-app-id"], { from: "user" });
+
+    expect(addParseSpy).toHaveBeenCalledWith(["my-app-id"], { from: "user" });
+  });
+});
+
+describe("sso forwards appId", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    setupMocks();
+  });
+
+  it("passes appId to requireAzureBot", async () => {
+    const { select } = await import("@inquirer/prompts");
+    const mockedSelect = vi.mocked(select);
+    mockedSelect.mockResolvedValueOnce("back" as never);
+
+    const { requireAzureBot } = await import(
+      "../src/commands/app/user-auth/require-azure.js"
+    );
+
+    const { ssoCommand } = await import(
+      "../src/commands/app/user-auth/sso/index.js"
+    );
+
+    await ssoCommand.parseAsync(["my-app-id"], { from: "user" });
+
+    expect(requireAzureBot).toHaveBeenCalledWith("my-app-id");
+  });
+});
+
 describe("oauth menu loop", () => {
   beforeEach(() => {
     vi.resetModules();


### PR DESCRIPTION
## Summary
- **Bug fix:** `userAuthCommand`, `oauthCommand`, and `ssoCommand` were not accepting or forwarding the app ID from `showAppActions`, causing `requireAzureBot()` to re-prompt the user to select an app they already chose.
- Now all three menu commands accept `[appId]` and thread it through to leaf subcommands and `requireAzureBot()`.
- Adds 4 unit tests (red/green verified) asserting appId propagation at each level of the chain.

## Test plan
- [x] `pnpm test` — all 14 menu-loop tests pass
- [x] `node dist/index.js app` → Select app → User Auth → SSO — should NOT re-prompt for app selection
- [x] Same flow for OAuth — should NOT re-prompt for app selection
- [ ] `node dist/index.js app user-auth sso list` (no appId) — should still prompt for app selection (CLI direct invocation, expected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)