### PR TITLE
Add confirmation prompts before major actions

### DIFF
--- a/src/commands/app/auth/secret/generate.ts
+++ b/src/commands/app/auth/secret/generate.ts
@@ -4,6 +4,7 @@ import {
 	fetchApp,
 	getAadAppByClientId,
 } from "../../../../apps/index.js";
+import { confirmAction } from "../../../../utils/interactive.js";
 import {
 	getAccount,
 	getTokenSilent,
@@ -51,6 +52,10 @@ export async function generateSecret(opts: GenerateSecretOptions): Promise<void>
 		envPath = (await input({
 			message: "Path to .env file (leave empty to show in terminal):",
 		})) || undefined;
+	}
+
+	if (!await confirmAction("Generate a new client secret?", silent)) {
+		return;
 	}
 
 	const account = await getAccount();

--- a/src/commands/app/bot/migrate.ts
+++ b/src/commands/app/bot/migrate.ts
@@ -7,6 +7,7 @@ import { pickApp } from "../../../utils/app-picker.js";
 import { ensureAz, runAz } from "../../../utils/az.js";
 import { resolveSubscription, resolveResourceGroup } from "../../../utils/az-prompts.js";
 import { CliError, wrapAction } from "../../../utils/errors.js";
+import { confirmAction } from "../../../utils/interactive.js";
 import { outputJson } from "../../../utils/json-output.js";
 import { logger } from "../../../utils/logger.js";
 import { createSilentSpinner } from "../../../utils/spinner.js";
@@ -86,6 +87,11 @@ export const botMigrateCommand = new Command("migrate")
       logger.info(`${pc.dim("Bot ID:")} ${botId}`);
       logger.info(`${pc.dim("Current location:")} Teams (managed)`);
       logger.info();
+    }
+
+    // Confirm before Azure setup (avoid side effects like RG creation before user agrees)
+    if (!await confirmAction("Migrate this bot to Azure? The existing registration will be replaced.", silent)) {
+      return;
     }
 
     // Azure setup

--- a/src/commands/app/create.ts
+++ b/src/commands/app/create.ts
@@ -25,7 +25,7 @@ import { CliError, wrapAction } from "../../utils/errors.js";
 import { readAndValidateIcon } from "../../utils/icon.js";
 import { outputJson } from "../../utils/json-output.js";
 import { logger } from "../../utils/logger.js";
-import { isInteractive } from "../../utils/interactive.js";
+import { isInteractive, confirmAction } from "../../utils/interactive.js";
 import { getConfig } from "../../utils/config.js";
 import { ensureAz, runAz } from "../../utils/az.js";
 import { resolveSubscription, resolveResourceGroup } from "../../utils/az-prompts.js";
@@ -189,7 +189,11 @@ export const appCreateCommand = new Command("create")
 		const colorIcon = colorIconPath ? readAndValidateIcon(colorIconPath, 192) : undefined;
 		const outlineIcon = outlineIconPath ? readAndValidateIcon(outlineIconPath, 32) : undefined;
 
-		// ===== All inputs gathered, now do async work =====
+		// ===== All inputs gathered — confirm before proceeding =====
+		const locationLabel = location === "azure" ? "Azure" : "Teams-managed";
+		if (!await confirmAction(`Create Teams app "${name}" with ${locationLabel} bot?`, silent)) {
+			return;
+		}
 
 		// Get tokens
 		let spinner = createSilentSpinner("Acquiring tokens...", silent).start();

--- a/src/commands/app/user-auth/oauth/add.ts
+++ b/src/commands/app/user-auth/oauth/add.ts
@@ -3,7 +3,7 @@ import { input, search } from "@inquirer/prompts";
 import pc from "picocolors";
 import { createSilentSpinner } from "../../../../utils/spinner.js";
 import { runAz } from "../../../../utils/az.js";
-import { isInteractive } from "../../../../utils/interactive.js";
+import { isInteractive, confirmAction } from "../../../../utils/interactive.js";
 import { logger } from "../../../../utils/logger.js";
 import { CliError, wrapAction } from "../../../../utils/errors.js";
 import { requireAzureBot } from "../require-azure.js";
@@ -96,6 +96,11 @@ export const oauthAddCommand = new Command("add")
         throw new CliError("VALIDATION_MISSING", "--scopes is required in non-interactive mode.");
       }
       scopes = await input({ message: "Scopes (space-delimited):" });
+    }
+
+    // Confirm before proceeding
+    if (!await confirmAction(`Create OAuth connection "${connectionName}" using ${provider}?`)) {
+      return;
     }
 
     // Create the connection

--- a/src/commands/app/user-auth/oauth/remove.ts
+++ b/src/commands/app/user-auth/oauth/remove.ts
@@ -3,7 +3,7 @@ import { search } from "@inquirer/prompts";
 import pc from "picocolors";
 import { createSilentSpinner } from "../../../../utils/spinner.js";
 import { runAz } from "../../../../utils/az.js";
-import { isInteractive } from "../../../../utils/interactive.js";
+import { isInteractive, confirmAction } from "../../../../utils/interactive.js";
 import { logger } from "../../../../utils/logger.js";
 import { CliError, wrapAction } from "../../../../utils/errors.js";
 import { requireAzureBot } from "../require-azure.js";
@@ -59,6 +59,10 @@ export const oauthRemoveCommand = new Command("remove")
           return choices.filter((c) => c.value.toLowerCase().includes(term.toLowerCase()));
         },
       });
+    }
+
+    if (!await confirmAction(`Remove OAuth connection "${connectionName}"?`)) {
+      return;
     }
 
     const spinner = createSilentSpinner(`Removing "${connectionName}"...`).start();

--- a/src/commands/app/user-auth/require-azure.ts
+++ b/src/commands/app/user-auth/require-azure.ts
@@ -61,7 +61,7 @@ export async function requireAzureBot(appIdArg?: string, silent = false): Promis
   if (location === "tm") {
     if (isAutoConfirm() && isInteractive()) {
       logger.warn(pc.yellow("This feature requires an Azure bot. Auto-confirming migration..."));
-      await botMigrateCommand.parseAsync([appId], { from: "user" });
+      await botMigrateCommand.parseAsync([appId, "--yes"], { from: "user" });
 
       const newLocation = await getBotLocation(token, botId);
       if (newLocation !== "azure") {
@@ -76,7 +76,7 @@ export async function requireAzureBot(appIdArg?: string, silent = false): Promis
       });
 
       if (migrate) {
-        await botMigrateCommand.parseAsync([appId], { from: "user" });
+        await botMigrateCommand.parseAsync([appId, "--yes"], { from: "user" });
 
         const newLocation = await getBotLocation(token, botId);
         if (newLocation !== "azure") {

--- a/src/commands/app/user-auth/sso/remove.ts
+++ b/src/commands/app/user-auth/sso/remove.ts
@@ -3,7 +3,7 @@ import { search } from "@inquirer/prompts";
 import pc from "picocolors";
 import { createSilentSpinner } from "../../../../utils/spinner.js";
 import { runAz } from "../../../../utils/az.js";
-import { isInteractive } from "../../../../utils/interactive.js";
+import { isInteractive, confirmAction } from "../../../../utils/interactive.js";
 import { logger } from "../../../../utils/logger.js";
 import { CliError, wrapAction } from "../../../../utils/errors.js";
 import { requireAzureBot } from "../require-azure.js";
@@ -62,6 +62,10 @@ export const ssoRemoveCommand = new Command("remove")
           return choices.filter((c) => c.value.toLowerCase().includes(term.toLowerCase()));
         },
       });
+    }
+
+    if (!await confirmAction(`Remove SSO connection "${connectionName}"?`)) {
+      return;
     }
 
     // Remove the OAuth connection

--- a/src/commands/app/user-auth/sso/setup.ts
+++ b/src/commands/app/user-auth/sso/setup.ts
@@ -5,7 +5,7 @@ import { getTokenSilent, graphScopes } from "../../../../auth/index.js";
 import { getAadAppByClientId, getAadAppFull, updateAadApp, createClientSecret } from "../../../../apps/graph.js";
 import { updateAppDetails, fetchAppDetailsV2 } from "../../../../apps/api.js";
 import { runAz } from "../../../../utils/az.js";
-import { isInteractive } from "../../../../utils/interactive.js";
+import { isInteractive, confirmAction } from "../../../../utils/interactive.js";
 import { CliError, wrapAction } from "../../../../utils/errors.js";
 import { outputJson } from "../../../../utils/json-output.js";
 import { logger } from "../../../../utils/logger.js";
@@ -64,6 +64,11 @@ export const ssoSetupCommand = new Command("setup")
       scopes = await input({ message: "Scopes:", default: "User.Read" });
     }
     scopes = scopes ?? "User.Read";
+
+    // Confirm before proceeding
+    if (!await confirmAction("Set up SSO? This will configure the AAD app, create an OAuth connection, and update the manifest.", silent)) {
+      return;
+    }
 
     // Get Graph token (needed for both secret creation and AAD app updates)
     const graphToken = await getTokenSilent(graphScopes);

--- a/src/utils/interactive.ts
+++ b/src/utils/interactive.ts
@@ -1,3 +1,5 @@
+import { confirm } from "@inquirer/prompts";
+
 /**
  * Check whether the session is interactive (can show prompts).
  * Returns false when stdin is not a TTY or TEAMS_NO_INTERACTIVE is set.
@@ -15,4 +17,18 @@ export function setAutoConfirm(value: boolean): void {
 
 export function isAutoConfirm(): boolean {
   return autoConfirm;
+}
+
+/**
+ * Confirm a major action before proceeding.
+ * - Returns true immediately when --yes is active.
+ * - In interactive mode, prompts the user.
+ * - In non-interactive mode without --yes, returns true (caller already
+ *   provided explicit flags).
+ */
+export async function confirmAction(message: string, silent = false): Promise<boolean> {
+  if (autoConfirm) return true;
+  if (silent) return true;
+  if (!isInteractive()) return true;
+  return confirm({ message, default: true });
 }

--- a/src/utils/interactive.ts
+++ b/src/utils/interactive.ts
@@ -22,9 +22,8 @@ export function isAutoConfirm(): boolean {
 /**
  * Confirm a major action before proceeding.
  * - Returns true immediately when --yes is active.
- * - In interactive mode, prompts the user.
- * - In non-interactive mode without --yes, returns true (caller already
- *   provided explicit flags).
+ * - Returns true immediately in silent or non-interactive mode.
+ * - Otherwise, prompts the user in interactive mode.
  */
 export async function confirmAction(message: string, silent = false): Promise<boolean> {
   if (autoConfirm) return true;

--- a/tests/confirm-action.test.ts
+++ b/tests/confirm-action.test.ts
@@ -1,0 +1,121 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+/**
+ * Tests for the confirmAction() utility.
+ * Verifies behavior across modes: --yes, --json (silent), non-interactive, interactive.
+ *
+ * Strategy: mock only @inquirer/prompts and control the real module's state via
+ * setAutoConfirm() and process.stdin.isTTY / TEAMS_NO_INTERACTIVE env var.
+ */
+
+const mockConfirm = vi.fn();
+
+vi.mock("@inquirer/prompts", () => ({
+  confirm: (...args: unknown[]) => mockConfirm(...args),
+}));
+
+// Import the real module — we control its behavior via setAutoConfirm + env
+import { confirmAction, setAutoConfirm } from "../src/utils/interactive.js";
+
+describe("confirmAction", () => {
+  let originalIsTTY: PropertyDescriptor | undefined;
+  let originalNoInteractive: string | undefined;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    setAutoConfirm(false);
+    mockConfirm.mockResolvedValue(true);
+
+    // Save originals
+    originalIsTTY = Object.getOwnPropertyDescriptor(process.stdin, "isTTY");
+    originalNoInteractive = process.env.TEAMS_NO_INTERACTIVE;
+
+    // Default: interactive TTY
+    Object.defineProperty(process.stdin, "isTTY", { value: true, configurable: true });
+    delete process.env.TEAMS_NO_INTERACTIVE;
+  });
+
+  afterEach(() => {
+    // Restore originals
+    if (originalIsTTY) {
+      Object.defineProperty(process.stdin, "isTTY", originalIsTTY);
+    } else {
+      Object.defineProperty(process.stdin, "isTTY", { value: undefined, configurable: true });
+    }
+    if (originalNoInteractive !== undefined) {
+      process.env.TEAMS_NO_INTERACTIVE = originalNoInteractive;
+    } else {
+      delete process.env.TEAMS_NO_INTERACTIVE;
+    }
+    setAutoConfirm(false);
+  });
+
+  it("returns true without prompting when --yes is active", async () => {
+    setAutoConfirm(true);
+
+    const result = await confirmAction("Do something?");
+
+    expect(result).toBe(true);
+    expect(mockConfirm).not.toHaveBeenCalled();
+  });
+
+  it("returns true without prompting when silent (--json)", async () => {
+    const result = await confirmAction("Do something?", true);
+
+    expect(result).toBe(true);
+    expect(mockConfirm).not.toHaveBeenCalled();
+  });
+
+  it("returns true without prompting when non-interactive (no TTY)", async () => {
+    Object.defineProperty(process.stdin, "isTTY", { value: false, configurable: true });
+
+    const result = await confirmAction("Do something?");
+
+    expect(result).toBe(true);
+    expect(mockConfirm).not.toHaveBeenCalled();
+  });
+
+  it("returns true without prompting when TEAMS_NO_INTERACTIVE is set", async () => {
+    process.env.TEAMS_NO_INTERACTIVE = "1";
+
+    const result = await confirmAction("Do something?");
+
+    expect(result).toBe(true);
+    expect(mockConfirm).not.toHaveBeenCalled();
+  });
+
+  it("prompts and returns true when user accepts", async () => {
+    mockConfirm.mockResolvedValue(true);
+
+    const result = await confirmAction("Create app?");
+
+    expect(result).toBe(true);
+    expect(mockConfirm).toHaveBeenCalledOnce();
+    expect(mockConfirm).toHaveBeenCalledWith({ message: "Create app?", default: true });
+  });
+
+  it("prompts and returns false when user declines", async () => {
+    mockConfirm.mockResolvedValue(false);
+
+    const result = await confirmAction("Create app?");
+
+    expect(result).toBe(false);
+    expect(mockConfirm).toHaveBeenCalledOnce();
+  });
+
+  it("--yes takes priority over interactive mode", async () => {
+    setAutoConfirm(true);
+
+    const result = await confirmAction("Do something?");
+
+    expect(result).toBe(true);
+    expect(mockConfirm).not.toHaveBeenCalled();
+  });
+
+  it("silent takes priority over interactive mode", async () => {
+    const result = await confirmAction("Do something?", true);
+
+    expect(result).toBe(true);
+    expect(mockConfirm).not.toHaveBeenCalled();
+  });
+});

--- a/tests/confirm-action.test.ts
+++ b/tests/confirm-action.test.ts
@@ -1,3 +1,6 @@
+// RED/GREEN: verified 2026-04-09 — each guard (autoConfirm, silent, isInteractive, confirm call)
+// was broken individually and the expected tests failed before restoring correct code.
+
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 
 /**

--- a/tests/menu-loop.test.ts
+++ b/tests/menu-loop.test.ts
@@ -26,6 +26,7 @@ function setupMocks(): void {
     isInteractive: () => true,
     isAutoConfirm: () => false,
     setAutoConfirm: vi.fn(),
+    confirmAction: vi.fn().mockResolvedValue(true),
   }));
 
   vi.mock("../src/utils/spinner.js", () => ({


### PR DESCRIPTION
## Summary
- Add `confirmAction()` utility to `src/utils/interactive.ts` — prompts user in interactive mode, auto-confirms with `--yes` or in `--json`/non-interactive mode
- Add confirmation prompts to 7 major actions: `app create`, `app bot migrate`, `auth secret create`, `sso setup`, `sso remove`, `oauth add`, `oauth remove`
- Place `migrate` confirm before Azure setup to avoid side effects (RG creation) if user declines

## Test plan
- [ ] Run `teams app create` interactively → confirm prompt appears before API calls
- [ ] Run `teams app create --name test --yes` → no prompt, proceeds directly
- [ ] Run `teams app create --name test --json` → no prompt, JSON output unbroken
- [ ] Run `teams app bot migrate` interactively → confirm appears before Azure CLI prompts
- [ ] Decline a confirmation → command exits cleanly with no side effects

🤖 Generated with [Claude Code](https://claude.com/claude-code)