### PR TITLE
refactor: make --json a boolean flag on app list and app view

### DIFF
--- a/src/commands/app/list.ts
+++ b/src/commands/app/list.ts
@@ -1,18 +1,16 @@
 import { Command } from "commander";
 import { search } from "@inquirer/prompts";
-import { createSpinner } from "nanospinner";
+import { createSilentSpinner } from "../../utils/spinner.js";
 import pc from "picocolors";
 import { getAccount, getTokenSilent, teamsDevPortalScopes } from "../../auth/index.js";
 import { fetchApps, fetchApp } from "../../apps/index.js";
 import { showAppActions } from "./actions.js";
-import { parseJsonFields, pickFields, outputJson } from "../../utils/json-output.js";
+import { outputJson } from "../../utils/json-output.js";
 import { isInteractive } from "../../utils/interactive.js";
 import { CliError, wrapAction } from "../../utils/errors.js";
 import { logger } from "../../utils/logger.js";
 
-const LIST_JSON_FIELDS = ["appId", "teamsAppId", "appName", "version", "updatedAt"];
-
-export async function runAppList(options?: { json?: string }): Promise<void> {
+export async function runAppList(options?: { json?: boolean }): Promise<void> {
   const account = await getAccount();
   if (!account) {
     throw new CliError("AUTH_REQUIRED", "Not logged in.", "Run `teams login` first.");
@@ -23,7 +21,8 @@ export async function runAppList(options?: { json?: string }): Promise<void> {
     throw new CliError("AUTH_TOKEN_FAILED", "Failed to get token.", "Try `teams login` again.");
   }
 
-  const spinner = createSpinner("Fetching apps...").start();
+  const silent = !!options?.json;
+  const spinner = createSilentSpinner("Fetching apps...", silent).start();
   let apps;
   try {
     apps = await fetchApps(token);
@@ -43,8 +42,7 @@ export async function runAppList(options?: { json?: string }): Promise<void> {
   }
 
   if (options?.json) {
-    const fields = parseJsonFields(options.json, LIST_JSON_FIELDS);
-    outputJson(pickFields(apps, fields));
+    outputJson(apps);
     return;
   }
 
@@ -85,7 +83,7 @@ export async function runAppList(options?: { json?: string }): Promise<void> {
 
 export const appListCommand = new Command("list")
   .description("List your Teams apps")
-  .option("--json <fields>", "[OPTIONAL] Output as JSON with specified fields")
+  .option("--json", "[OPTIONAL] Output as JSON")
   .action(wrapAction(async (options) => {
     await runAppList(options);
   }));

--- a/src/commands/app/view.ts
+++ b/src/commands/app/view.ts
@@ -1,33 +1,17 @@
 import { Command } from "commander";
 import pc from "picocolors";
-import { createSpinner } from "nanospinner";
+import { createSilentSpinner } from "../../utils/spinner.js";
 import { getAccount, getTokenSilent, teamsDevPortalScopes } from "../../auth/index.js";
 import { fetchApp, fetchAppDetailsV2, showAppDetail } from "../../apps/index.js";
-import { parseJsonFields, pickFields, outputJson } from "../../utils/json-output.js";
+import { outputJson } from "../../utils/json-output.js";
 import { pickApp } from "../../utils/app-picker.js";
 import { CliError, wrapAction } from "../../utils/errors.js";
 import { logger } from "../../utils/logger.js";
 
-const VIEW_JSON_FIELDS = [
-  "appId",
-  "teamsAppId",
-  "name",
-  "longName",
-  "version",
-  "developer",
-  "shortDescription",
-  "longDescription",
-  "websiteUrl",
-  "privacyUrl",
-  "termsOfUseUrl",
-  "endpoint",
-  "installLink",
-];
-
 export const appViewCommand = new Command("view")
   .description("View a Teams app")
   .argument("[appId]", "App ID")
-  .option("--json <fields>", "[OPTIONAL] Output as JSON with specified fields")
+  .option("--json", "[OPTIONAL] Output as JSON")
   .option("--web", "[OPTIONAL] Print the Teams install link")
   .action(wrapAction(async (appIdArg: string | undefined, options) => {
     // Interactive picker loop when no appId
@@ -60,8 +44,7 @@ export const appViewCommand = new Command("view")
     const app = await fetchApp(token, appIdArg);
 
     if (options.json) {
-      const fields = parseJsonFields(options.json, VIEW_JSON_FIELDS);
-      const spinner = createSpinner("Fetching app details...").start();
+      const spinner = createSilentSpinner("Fetching app details...", true).start();
       const details = await fetchAppDetailsV2(token, app.teamsAppId);
       spinner.stop();
 
@@ -81,7 +64,7 @@ export const appViewCommand = new Command("view")
         installLink: `https://teams.microsoft.com/l/app/${details.teamsAppId}?installAppPackage=true`,
       };
 
-      outputJson(pickFields(enriched as Record<string, unknown>, fields));
+      outputJson(enriched);
       return;
     }
 

--- a/src/utils/json-output.ts
+++ b/src/utils/json-output.ts
@@ -1,35 +1,3 @@
-import { CliError } from "./errors.js";
-
-export function parseJsonFields(fieldsArg: string, allowedFields: string[]): string[] {
-  const fields = fieldsArg.split(",").map((f) => f.trim()).filter(Boolean);
-
-  const invalid = fields.filter((f) => !allowedFields.includes(f));
-  if (invalid.length > 0) {
-    throw new CliError(
-      "VALIDATION_FORMAT",
-      `Unknown field(s): ${invalid.join(", ")}`,
-      `Available: ${allowedFields.join(", ")}`,
-    );
-  }
-
-  return fields;
-}
-
-export function pickFields<T extends object>(
-  data: T | T[],
-  fields: string[]
-): Record<string, unknown> | Record<string, unknown>[] {
-  const pick = (obj: T) => {
-    const result: Record<string, unknown> = {};
-    for (const f of fields) {
-      result[f] = (obj as Record<string, unknown>)[f];
-    }
-    return result;
-  };
-
-  return Array.isArray(data) ? data.map(pick) : pick(data);
-}
-
 export function outputJson(data: unknown): void {
   console.log(JSON.stringify(data, null, 2));
 }

--- a/tests/json-boolean-flag.test.ts
+++ b/tests/json-boolean-flag.test.ts
@@ -1,0 +1,111 @@
+// RED/GREEN: verified 2026-04-10
+// RED: reverted --json to `--json <fields>` in list.ts — test failed because
+//      `runAppList({ json: true })` passed a boolean where a string was expected,
+//      causing parseJsonFields to throw on `.split()`.
+// GREEN: restored boolean `--json` — test passes.
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const FAKE_APPS = [
+  {
+    appId: "app-1",
+    appName: "Test App",
+    teamsAppId: "teams-1",
+    version: "1.0.0",
+    updatedAt: "2026-01-01",
+  },
+  {
+    appId: "app-2",
+    appName: "Another App",
+    teamsAppId: "teams-2",
+    version: "2.0.0",
+    updatedAt: "2026-02-01",
+  },
+];
+
+function setupMocks(): void {
+  vi.mock("../src/auth/index.js", () => ({
+    getAccount: vi.fn().mockResolvedValue({ tenantId: "fake-tenant" }),
+    getTokenSilent: vi.fn().mockResolvedValue("fake-token"),
+    teamsDevPortalScopes: ["https://dev.teams.microsoft.com/.default"],
+  }));
+
+  vi.mock("../src/apps/index.js", () => ({
+    fetchApps: vi.fn().mockResolvedValue(FAKE_APPS),
+    fetchApp: vi.fn(),
+    fetchAppDetailsV2: vi.fn(),
+    showAppDetail: vi.fn(),
+  }));
+
+  vi.mock("../src/utils/spinner.js", () => ({
+    createSilentSpinner: () => ({
+      start: vi.fn().mockReturnThis(),
+      stop: vi.fn(),
+      error: vi.fn(),
+    }),
+  }));
+
+  vi.mock("../src/utils/interactive.js", () => ({
+    isInteractive: () => false,
+    isAutoConfirm: () => false,
+    setAutoConfirm: vi.fn(),
+  }));
+
+  vi.mock("../src/utils/logger.js", () => ({
+    logger: {
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+      debug: vi.fn(),
+    },
+  }));
+}
+
+describe("app list --json as boolean flag", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    setupMocks();
+  });
+
+  it("outputs all apps with all fields when --json is true", async () => {
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+
+    const { runAppList } = await import("../src/commands/app/list.js");
+    await runAppList({ json: true });
+
+    const output = logSpy.mock.calls.map((c) => c[0]).join("\n");
+    const parsed = JSON.parse(output);
+
+    expect(Array.isArray(parsed)).toBe(true);
+    expect(parsed).toHaveLength(2);
+    // All fields present — not filtered
+    expect(parsed[0]).toHaveProperty("appId", "app-1");
+    expect(parsed[0]).toHaveProperty("appName", "Test App");
+    expect(parsed[0]).toHaveProperty("teamsAppId", "teams-1");
+    expect(parsed[0]).toHaveProperty("version", "1.0.0");
+    expect(parsed[0]).toHaveProperty("updatedAt", "2026-01-01");
+    expect(parsed[1]).toHaveProperty("appId", "app-2");
+
+    logSpy.mockRestore();
+  });
+
+  it("outputs empty array when no apps exist", async () => {
+    vi.doMock("../src/apps/index.js", () => ({
+      fetchApps: vi.fn().mockResolvedValue([]),
+      fetchApp: vi.fn(),
+      fetchAppDetailsV2: vi.fn(),
+      showAppDetail: vi.fn(),
+    }));
+
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+
+    const { runAppList } = await import("../src/commands/app/list.js");
+    await runAppList({ json: true });
+
+    const output = logSpy.mock.calls.map((c) => c[0]).join("\n");
+    expect(JSON.parse(output)).toEqual([]);
+
+    logSpy.mockRestore();
+  });
+});


### PR DESCRIPTION
## Summary
- `--json` is now a standard boolean flag on `app list` and `app view`, matching all other commands
- Removes `parseJsonFields`/`pickFields` utilities (no longer used)
- Fixes spinner contamination in JSON mode by using `createSilentSpinner`

## Test plan
- [x] `pnpm build` — compiles cleanly
- [x] `pnpm test` — unit tests pass (including new red/green `json-boolean-flag.test.ts`)
- [x] `teams app list --json` — outputs all apps with all fields as valid JSON

🤖 Generated with [Claude Code](https://claude.com/claude-code)