### PR TITLE
fix: move icon options into Icons submenu during app creation

### DIFF
--- a/src/apps/manifest-builder.ts
+++ b/src/apps/manifest-builder.ts
@@ -20,7 +20,7 @@ export interface ManifestCustomization {
 
 /**
  * Interactively collects manifest customization options from the user.
- * Prompts for description, scopes, and developer details.
+ * Prompts for description, icons, scopes, and developer details.
  */
 export async function collectManifestCustomization(): Promise<ManifestCustomization> {
   if (!isInteractive()) {

--- a/src/apps/manifest-builder.ts
+++ b/src/apps/manifest-builder.ts
@@ -8,6 +8,7 @@ export const PLACEHOLDER_BOT_ID = "00000000-0000-0000-0000-000000000000";
 
 export interface ManifestCustomization {
   description?: { short: string; full?: string };
+  icons?: { colorIconPath?: string; outlineIconPath?: string };
   scopes?: string[];
   developer?: {
     name: string;
@@ -30,6 +31,7 @@ export async function collectManifestCustomization(): Promise<ManifestCustomizat
     message: "Customize manifest fields? (space to select, enter to continue)",
     choices: [
       { name: "Description", value: "description" },
+      { name: "Icons", value: "icons" },
       { name: "Scopes", value: "scopes" },
       { name: "Developer details", value: "developer" },
     ],
@@ -41,6 +43,16 @@ export async function collectManifestCustomization(): Promise<ManifestCustomizat
     const shortDesc = await input({ message: "Short description:" });
     const fullDesc = await input({ message: "Full description (leave empty to use short):" });
     result.description = { short: shortDesc, full: fullDesc || undefined };
+  }
+
+  if (customizeFields.includes("icons")) {
+    const colorIconPath =
+      (await input({ message: "Color icon path (192x192 PNG, leave empty to skip):" })) || undefined;
+    const outlineIconPath =
+      (await input({ message: "Outline icon path (32x32 PNG, leave empty to skip):" })) || undefined;
+    if (colorIconPath || outlineIconPath) {
+      result.icons = { colorIconPath, outlineIconPath };
+    }
   }
 
   if (customizeFields.includes("scopes")) {

--- a/src/commands/app/create.ts
+++ b/src/commands/app/create.ts
@@ -166,24 +166,15 @@ export const appCreateCommand = new Command("create")
 			descriptionOpts = customization.description;
 			scopeChoices = customization.scopes;
 			developerOpts = customization.developer;
+			if (customization.icons) {
+				options.colorIcon ??= customization.icons.colorIconPath;
+				options.outlineIcon ??= customization.icons.outlineIconPath;
+			}
 		}
 
-		// Get icon paths (prompt only in full interactive mode)
-		const colorIconPath =
-			options.colorIcon ??
-			(interactive && !hasFlags
-				? (await input({
-						message: "Color icon path (192x192 PNG, leave empty to skip):",
-				  })) || undefined
-				: undefined);
-
-		const outlineIconPath =
-			options.outlineIcon ??
-			(interactive && !hasFlags
-				? (await input({
-						message: "Outline icon path (32x32 PNG, leave empty to skip):",
-				  })) || undefined
-				: undefined);
+		// Resolve icon paths (CLI flags take priority, then interactive selection)
+		const colorIconPath = options.colorIcon;
+		const outlineIconPath = options.outlineIcon;
 
 		// Validate icons upfront (before any API calls)
 		const colorIcon = colorIconPath ? readAndValidateIcon(colorIconPath, 192) : undefined;

--- a/src/commands/app/create.ts
+++ b/src/commands/app/create.ts
@@ -161,7 +161,7 @@ export const appCreateCommand = new Command("create")
 			  }
 			| undefined;
 
-		if (interactive && !hasFlags) {
+		if (interactive && !hasFlags && !options.json) {
 			const customization = await collectManifestCustomization();
 			descriptionOpts = customization.description;
 			scopeChoices = customization.scopes;

--- a/tests/manifest-builder-icons.test.ts
+++ b/tests/manifest-builder-icons.test.ts
@@ -1,0 +1,87 @@
+// RED/GREEN: verified 2026-04-10
+// RED: removed "Icons" choice from checkbox in manifest-builder.ts — test failed
+//      because checkbox choices did not include { value: "icons" }.
+// GREEN: restored "Icons" choice — test passes.
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("../src/utils/interactive.js", () => ({
+  isInteractive: () => true,
+}));
+
+vi.mock("@inquirer/prompts", () => ({
+  checkbox: vi.fn(),
+  input: vi.fn(),
+}));
+
+describe("collectManifestCustomization icons", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+  });
+
+  it("offers Icons as a checkbox choice and returns icon paths when selected", async () => {
+    const { checkbox, input } = await import("@inquirer/prompts");
+    const mockedCheckbox = vi.mocked(checkbox);
+    const mockedInput = vi.mocked(input);
+
+    mockedCheckbox.mockResolvedValueOnce(["icons"] as never);
+    mockedInput
+      .mockResolvedValueOnce("./color.png" as never)
+      .mockResolvedValueOnce("./outline.png" as never);
+
+    const { collectManifestCustomization } = await import(
+      "../src/apps/manifest-builder.js"
+    );
+
+    const result = await collectManifestCustomization();
+
+    // Verify "Icons" is offered as a choice
+    const checkboxCall = mockedCheckbox.mock.calls[0][0] as {
+      choices: Array<{ name: string; value: string }>;
+    };
+    const iconChoice = checkboxCall.choices.find((c) => c.value === "icons");
+    expect(iconChoice).toBeDefined();
+    expect(iconChoice!.name).toBe("Icons");
+
+    // Verify icon paths are returned
+    expect(result.icons).toEqual({
+      colorIconPath: "./color.png",
+      outlineIconPath: "./outline.png",
+    });
+  });
+
+  it("omits icons when not selected", async () => {
+    const { checkbox } = await import("@inquirer/prompts");
+    const mockedCheckbox = vi.mocked(checkbox);
+
+    mockedCheckbox.mockResolvedValueOnce([] as never);
+
+    const { collectManifestCustomization } = await import(
+      "../src/apps/manifest-builder.js"
+    );
+
+    const result = await collectManifestCustomization();
+
+    expect(result.icons).toBeUndefined();
+  });
+
+  it("omits icons when both paths are empty", async () => {
+    const { checkbox, input } = await import("@inquirer/prompts");
+    const mockedCheckbox = vi.mocked(checkbox);
+    const mockedInput = vi.mocked(input);
+
+    mockedCheckbox.mockResolvedValueOnce(["icons"] as never);
+    mockedInput
+      .mockResolvedValueOnce("" as never)
+      .mockResolvedValueOnce("" as never);
+
+    const { collectManifestCustomization } = await import(
+      "../src/apps/manifest-builder.js"
+    );
+
+    const result = await collectManifestCustomization();
+
+    expect(result.icons).toBeUndefined();
+  });
+});

--- a/tests/manifest-builder-icons.test.ts
+++ b/tests/manifest-builder-icons.test.ts
@@ -51,9 +51,10 @@ describe("collectManifestCustomization icons", () => {
     });
   });
 
-  it("omits icons when not selected", async () => {
-    const { checkbox } = await import("@inquirer/prompts");
+  it("omits icons and does not prompt for paths when not selected", async () => {
+    const { checkbox, input } = await import("@inquirer/prompts");
     const mockedCheckbox = vi.mocked(checkbox);
+    const mockedInput = vi.mocked(input);
 
     mockedCheckbox.mockResolvedValueOnce([] as never);
 
@@ -64,6 +65,7 @@ describe("collectManifestCustomization icons", () => {
     const result = await collectManifestCustomization();
 
     expect(result.icons).toBeUndefined();
+    expect(mockedInput).not.toHaveBeenCalled();
   });
 
   it("omits icons when both paths are empty", async () => {


### PR DESCRIPTION
## Summary
- During `teams app create`, icon path prompts (color/outline) were standalone inputs after the manifest customization menu — they should have been inside it
- Added "Icons" as a selectable choice in the "Customize manifest fields?" checkbox, alongside Description, Scopes, and Developer details
- CLI flags (`--color-icon`, `--outline-icon`) still take priority over interactive selection

## Test plan
- [x] Red/green verified: removed "Icons" choice → test fails; restored → test passes
- [x] `pnpm build` compiles cleanly
- [x] `pnpm test` — all 33 tests pass
- [ ] Manual: run `node dist/index.js app create` interactively, verify "Icons" appears in the customize checkbox

🤖 Generated with [Claude Code](https://claude.com/claude-code)