### PR TITLE
fix: auto-set webApplicationInfoId for RSC permissions

### DIFF
--- a/src/apps/types.ts
+++ b/src/apps/types.ts
@@ -50,6 +50,8 @@ export interface AppDetails {
   // Additional fields that must be preserved
   manifestVersion: string;
   webApplicationInfoId: string;
+  webApplicationInfoResource?: string;
+  validDomains?: string[];
   mpnId: string;
   accentColor: string;
   colorIcon?: string;

--- a/src/commands/app/doctor.ts
+++ b/src/commands/app/doctor.ts
@@ -329,7 +329,12 @@ function checkManifest(
       }
     }
   } else {
-    results.push({ category: cat, label: "webApplicationInfo not configured", status: "info", detail: "SSO not set up" });
+    const hasRsc = (details.authorization?.permissions?.resourceSpecific ?? []).length > 0;
+    if (hasRsc) {
+      results.push({ category: cat, label: "webApplicationInfo not configured", status: "fail", detail: "Required when RSC permissions are present" });
+    } else {
+      results.push({ category: cat, label: "webApplicationInfo not configured", status: "info", detail: "SSO not set up" });
+    }
   }
 }
 

--- a/src/commands/app/doctor.ts
+++ b/src/commands/app/doctor.ts
@@ -294,7 +294,7 @@ function checkManifest(
     results.push({ category: cat, label: "Bot ID does not match app ID", status: "warn", detail: `appId=${details.appId}, botId=${botId}` });
   }
 
-  const validDomains = (details.validDomains ?? []) as string[];
+  const validDomains = details.validDomains ?? [];
 
   // validDomains includes endpoint domain
   if (endpoint) {
@@ -319,7 +319,7 @@ function checkManifest(
     results.push({ category: cat, label: "webApplicationInfo configured", status: "pass" });
 
     // Check resource URI format
-    const resource = details.webApplicationInfoResource as string | undefined;
+    const resource = details.webApplicationInfoResource;
     if (resource) {
       const expected = `api://botid-${botId}`;
       if (resource.startsWith(expected)) {
@@ -443,7 +443,7 @@ async function checkSso(
           const tokenExchange = params.find((p) => p.key === "tokenExchangeUrl")?.value;
 
           if (tokenExchange) {
-            const manifestResource = (details.webApplicationInfoResource as string | undefined) ?? "";
+            const manifestResource = (details.webApplicationInfoResource) ?? "";
             const aadIdentifier = identifierUris[0] ?? "";
 
             const allMatch = tokenExchange === aadIdentifier && tokenExchange === manifestResource;

--- a/src/commands/app/rsc/actions.ts
+++ b/src/commands/app/rsc/actions.ts
@@ -25,11 +25,12 @@ async function buildAuthorizationUpdate(
   token: string,
   teamsAppId: string,
   newResourceSpecific: RscPermissionEntry[],
-): Promise<{ authorization: AppAuthorization }> {
+): Promise<{ authorization: AppAuthorization; webApplicationInfoId?: string }> {
   const details = await fetchAppDetailsV2(token, teamsAppId);
   const currentAuth = details.authorization ?? {};
   const currentPerms = currentAuth.permissions ?? {};
-  return {
+
+  const update: { authorization: AppAuthorization; webApplicationInfoId?: string } = {
     authorization: {
       ...currentAuth,
       permissions: {
@@ -38,6 +39,13 @@ async function buildAuthorizationUpdate(
       },
     },
   };
+
+  // RSC permissions require webApplicationInfo.id in the manifest
+  if (!details.webApplicationInfoId && newResourceSpecific.length > 0) {
+    update.webApplicationInfoId = details.appId;
+  }
+
+  return update;
 }
 
 /**

--- a/src/commands/app/user-auth/sso/setup.ts
+++ b/src/commands/app/user-auth/sso/setup.ts
@@ -4,6 +4,7 @@ import pc from "picocolors";
 import { getTokenSilent, graphScopes } from "../../../../auth/index.js";
 import { getAadAppByClientId, getAadAppFull, updateAadApp, createClientSecret } from "../../../../apps/graph.js";
 import { updateAppDetails, fetchAppDetailsV2 } from "../../../../apps/api.js";
+import type { AppDetails } from "../../../../apps/types.js";
 import { runAz } from "../../../../utils/az.js";
 import { isInteractive, confirmAction } from "../../../../utils/interactive.js";
 import { CliError, wrapAction } from "../../../../utils/errors.js";
@@ -210,9 +211,9 @@ export const ssoSetupCommand = new Command("setup")
     const manifestSpinner = createSilentSpinner("Updating manifest...", silent).start();
     try {
       const details = await fetchAppDetailsV2(token, appId);
-      const validDomains = (details.validDomains as string[]) ?? [];
-      const updates: Record<string, unknown> = {
-        webApplicationInfoId: botId,
+      const validDomains = details.validDomains ?? [];
+      const updates: Partial<AppDetails> = {
+        webApplicationInfoId: details.appId,
         webApplicationInfoResource: `api://botid-${botId}`,
       };
 

--- a/tests/rsc-web-app-info.test.ts
+++ b/tests/rsc-web-app-info.test.ts
@@ -1,0 +1,102 @@
+// RED/GREEN: verified 2026-04-10 — removed the webApplicationInfoId auto-set
+// from buildAuthorizationUpdate and confirmed both "sets webApplicationInfoId"
+// tests failed. Restored code and confirmed they pass.
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { AppDetails, RscPermissionEntry } from "../src/apps/types.js";
+
+/**
+ * Tests that RSC write operations auto-set webApplicationInfoId when missing.
+ * The manifest requires webApplicationInfo.id whenever RSC permissions exist.
+ */
+
+// --- Mocks ---
+
+const mockDetails: AppDetails = {
+  teamsAppId: "test-teams-app-id",
+  appId: "00000000-0000-0000-0000-000000000001",
+  shortName: "Test App",
+  longName: "Test App",
+  shortDescription: "desc",
+  longDescription: "desc",
+  version: "1.0.0",
+  developerName: "dev",
+  websiteUrl: "https://example.com",
+  privacyUrl: "https://example.com/privacy",
+  termsOfUseUrl: "https://example.com/terms",
+  manifestVersion: "1.16",
+  webApplicationInfoId: "",
+  mpnId: "",
+  accentColor: "#FFFFFF",
+  authorization: { permissions: { resourceSpecific: [] } },
+};
+
+let capturedUpdate: Partial<AppDetails> | null = null;
+
+vi.mock("../src/apps/api.js", () => ({
+  fetchAppDetailsV2: vi.fn(async () => structuredClone(mockDetails)),
+  updateAppDetails: vi.fn(async (_token: string, _id: string, update: Partial<AppDetails>) => {
+    capturedUpdate = update;
+    return { ...mockDetails, ...update };
+  }),
+}));
+
+import { addRscPermissions, setRscPermissions, removeRscPermissions } from "../src/commands/app/rsc/actions.js";
+
+describe("RSC webApplicationInfoId auto-set", () => {
+  beforeEach(() => {
+    capturedUpdate = null;
+    // Reset to empty webApplicationInfoId
+    mockDetails.webApplicationInfoId = "";
+    mockDetails.authorization = { permissions: { resourceSpecific: [] } };
+  });
+
+  it("sets webApplicationInfoId to appId when adding RSC permissions and it is empty", async () => {
+    const perms: RscPermissionEntry[] = [
+      { name: "ChannelMessage.Read.Group", type: "Application" },
+    ];
+
+    await addRscPermissions("fake-token", "test-teams-app-id", perms);
+
+    expect(capturedUpdate).not.toBeNull();
+    expect(capturedUpdate!.webApplicationInfoId).toBe(mockDetails.appId);
+  });
+
+  it("sets webApplicationInfoId to appId when calling setRscPermissions and it is empty", async () => {
+    const perms: RscPermissionEntry[] = [
+      { name: "TeamSettings.ReadWrite.Group", type: "Application" },
+    ];
+
+    await setRscPermissions("fake-token", "test-teams-app-id", perms);
+
+    expect(capturedUpdate).not.toBeNull();
+    expect(capturedUpdate!.webApplicationInfoId).toBe(mockDetails.appId);
+  });
+
+  it("does NOT overwrite webApplicationInfoId when it is already set", async () => {
+    mockDetails.webApplicationInfoId = "existing-aad-app-id";
+
+    const perms: RscPermissionEntry[] = [
+      { name: "ChannelMessage.Read.Group", type: "Application" },
+    ];
+
+    await addRscPermissions("fake-token", "test-teams-app-id", perms);
+
+    expect(capturedUpdate).not.toBeNull();
+    expect(capturedUpdate!.webApplicationInfoId).toBeUndefined();
+  });
+
+  it("does NOT set webApplicationInfoId when removing all RSC permissions", async () => {
+    mockDetails.authorization = {
+      permissions: {
+        resourceSpecific: [{ name: "ChannelMessage.Read.Group", type: "Application" }],
+      },
+    };
+
+    await removeRscPermissions("fake-token", "test-teams-app-id", ["ChannelMessage.Read.Group"]);
+
+    expect(capturedUpdate).not.toBeNull();
+    // After removing the only permission, resourceSpecific is empty — no need to set webApplicationInfoId
+    expect(capturedUpdate!.webApplicationInfoId).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary
- RSC permissions require `webApplicationInfo.id` in the manifest, but it was only set during SSO setup — causing validation errors when adding RSC without SSO
- `buildAuthorizationUpdate` now auto-sets `webApplicationInfoId` to `appId` when it's empty and RSC permissions are being written
- Doctor command now flags missing `webApplicationInfo` as a **fail** (not info) when RSC permissions are present

## Test plan
- [x] Unit test: `webApplicationInfoId` is set to `appId` on `addRscPermissions` when empty
- [x] Unit test: `webApplicationInfoId` is set to `appId` on `setRscPermissions` when empty
- [x] Unit test: existing `webApplicationInfoId` is NOT overwritten
- [x] Unit test: removing all RSC permissions does NOT set `webApplicationInfoId`
- [x] Red/green verified: broke the auto-set code, confirmed 2 tests fail, restored and confirmed all 4 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)