### PR TITLE
feat: add manifest upload command

### DIFF
--- a/src/commands/app/manifest/actions.ts
+++ b/src/commands/app/manifest/actions.ts
@@ -29,7 +29,7 @@ export async function downloadManifest(token: string, appId: string, filePath?: 
     const manifestContent = manifestEntry.getData().toString("utf-8");
     manifestJson = JSON.parse(manifestContent);
   } catch (error) {
-    spinner.error({ text: "Download failed" });
+    spinner.error({ text: error instanceof Error ? error.message : "Download failed" });
     throw error;
   }
 

--- a/src/commands/app/manifest/actions.ts
+++ b/src/commands/app/manifest/actions.ts
@@ -16,17 +16,22 @@ import { createSilentSpinner } from "../../../utils/spinner.js";
 export async function downloadManifest(token: string, appId: string, filePath?: string): Promise<void> {
   const spinner = createSilentSpinner("Downloading manifest...", false).start();
 
-  const packageBuffer = await downloadAppPackage(token, appId);
-  const zip = new AdmZip(packageBuffer);
-  const manifestEntry = zip.getEntry("manifest.json");
+  let manifestJson: unknown;
+  try {
+    const packageBuffer = await downloadAppPackage(token, appId);
+    const zip = new AdmZip(packageBuffer);
+    const manifestEntry = zip.getEntry("manifest.json");
 
-  if (!manifestEntry) {
-    spinner.error({ text: "manifest.json not found in package" });
-    throw new Error("manifest.json not found in package");
+    if (!manifestEntry) {
+      throw new Error("manifest.json not found in package");
+    }
+
+    const manifestContent = manifestEntry.getData().toString("utf-8");
+    manifestJson = JSON.parse(manifestContent);
+  } catch (error) {
+    spinner.error({ text: "Download failed" });
+    throw error;
   }
-
-  const manifestContent = manifestEntry.getData().toString("utf-8");
-  const manifestJson = JSON.parse(manifestContent);
 
   spinner.success({ text: "Manifest downloaded" });
 
@@ -64,8 +69,13 @@ export async function uploadManifestFromFile(
 
   let manifest: TeamsManifest;
   try {
-    manifest = JSON.parse(raw);
-  } catch {
+    const parsed: unknown = JSON.parse(raw);
+    if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+      throw new CliError("VALIDATION_FORMAT", `File does not contain a JSON object: ${resolved}`);
+    }
+    manifest = parsed as TeamsManifest;
+  } catch (error) {
+    if (error instanceof CliError) throw error;
     throw new CliError("VALIDATION_FORMAT", `File is not valid JSON: ${resolved}`);
   }
 

--- a/src/commands/app/manifest/actions.ts
+++ b/src/commands/app/manifest/actions.ts
@@ -6,6 +6,7 @@ import { createSpinner } from "nanospinner";
 import { downloadAppPackage, uploadManifest, type TeamsManifest } from "../../../apps/index.js";
 import { CliError } from "../../../utils/errors.js";
 import { logger } from "../../../utils/logger.js";
+import { createSilentSpinner } from "../../../utils/spinner.js";
 
 /**
  * Download manifest from an app package. Saves to file or prints to stdout.
@@ -45,6 +46,7 @@ export async function uploadManifestFromFile(
   token: string,
   teamsAppId: string,
   filePath: string,
+  silent = false,
 ): Promise<void> {
   const resolved = path.resolve(filePath);
 
@@ -74,9 +76,16 @@ export async function uploadManifestFromFile(
     );
   }
 
-  const spinner = createSpinner("Uploading manifest...").start();
-  await uploadManifest(token, teamsAppId, manifest);
+  const spinner = createSilentSpinner("Uploading manifest...", silent).start();
+  try {
+    await uploadManifest(token, teamsAppId, manifest);
+  } catch (error) {
+    spinner.error({ text: "Upload failed" });
+    throw error;
+  }
   spinner.success({ text: "Manifest uploaded" });
 
-  logger.info(pc.green(`Manifest from ${pc.bold(resolved)} applied to app ${pc.bold(teamsAppId)}`));
+  if (!silent) {
+    logger.info(pc.green(`Manifest from ${pc.bold(resolved)} applied to app ${pc.bold(teamsAppId)}`));
+  }
 }

--- a/src/commands/app/manifest/actions.ts
+++ b/src/commands/app/manifest/actions.ts
@@ -1,8 +1,10 @@
 import AdmZip from "adm-zip";
-import { writeFile } from "node:fs/promises";
+import { readFile, writeFile } from "node:fs/promises";
+import path from "node:path";
 import pc from "picocolors";
 import { createSpinner } from "nanospinner";
-import { downloadAppPackage } from "../../../apps/index.js";
+import { downloadAppPackage, uploadManifest, type TeamsManifest } from "../../../apps/index.js";
+import { CliError } from "../../../utils/errors.js";
 import { logger } from "../../../utils/logger.js";
 
 /**
@@ -32,4 +34,49 @@ export async function downloadManifest(token: string, appId: string, filePath?: 
   } else {
     logger.info(JSON.stringify(manifestJson, null, 2));
   }
+}
+
+/**
+ * Upload a local manifest.json to update an existing app.
+ * Reads the file, validates it's a Teams manifest, and uploads via TDP API.
+ * Throws on failure.
+ */
+export async function uploadManifestFromFile(
+  token: string,
+  teamsAppId: string,
+  filePath: string,
+): Promise<void> {
+  const resolved = path.resolve(filePath);
+
+  let raw: string;
+  try {
+    raw = await readFile(resolved, "utf-8");
+  } catch (error) {
+    const code = (error as NodeJS.ErrnoException).code;
+    if (code === "ENOENT") {
+      throw new CliError("VALIDATION_MISSING", `File not found: ${resolved}`);
+    }
+    throw new CliError("VALIDATION_FORMAT", `Cannot read file: ${resolved}`);
+  }
+
+  let manifest: TeamsManifest;
+  try {
+    manifest = JSON.parse(raw);
+  } catch {
+    throw new CliError("VALIDATION_FORMAT", `File is not valid JSON: ${resolved}`);
+  }
+
+  if (!manifest.manifestVersion || !manifest.name?.short || !manifest.description?.short) {
+    throw new CliError(
+      "VALIDATION_FORMAT",
+      "File does not appear to be a valid Teams manifest.",
+      "Ensure it has manifestVersion, name.short, and description.short.",
+    );
+  }
+
+  const spinner = createSpinner("Uploading manifest...").start();
+  await uploadManifest(token, teamsAppId, manifest);
+  spinner.success({ text: "Manifest uploaded" });
+
+  logger.info(pc.green(`Manifest from ${pc.bold(resolved)} applied to app ${pc.bold(teamsAppId)}`));
 }

--- a/src/commands/app/manifest/actions.ts
+++ b/src/commands/app/manifest/actions.ts
@@ -2,9 +2,10 @@ import AdmZip from "adm-zip";
 import { readFile, writeFile } from "node:fs/promises";
 import path from "node:path";
 import pc from "picocolors";
-import { createSpinner } from "nanospinner";
+import { confirm } from "@inquirer/prompts";
 import { downloadAppPackage, uploadManifest, type TeamsManifest } from "../../../apps/index.js";
 import { CliError } from "../../../utils/errors.js";
+import { isAutoConfirm } from "../../../utils/interactive.js";
 import { logger } from "../../../utils/logger.js";
 import { createSilentSpinner } from "../../../utils/spinner.js";
 
@@ -13,7 +14,7 @@ import { createSilentSpinner } from "../../../utils/spinner.js";
  * Throws on failure.
  */
 export async function downloadManifest(token: string, appId: string, filePath?: string): Promise<void> {
-  const spinner = createSpinner("Downloading manifest...").start();
+  const spinner = createSilentSpinner("Downloading manifest...", false).start();
 
   const packageBuffer = await downloadAppPackage(token, appId);
   const zip = new AdmZip(packageBuffer);
@@ -68,12 +69,30 @@ export async function uploadManifestFromFile(
     throw new CliError("VALIDATION_FORMAT", `File is not valid JSON: ${resolved}`);
   }
 
-  if (!manifest.manifestVersion || !manifest.name?.short || !manifest.description?.short) {
-    throw new CliError(
-      "VALIDATION_FORMAT",
-      "File does not appear to be a valid Teams manifest.",
-      "Ensure it has manifestVersion, name.short, and description.short.",
-    );
+  const missing: string[] = [];
+  if (!manifest.id) missing.push("id");
+  if (!manifest.version) missing.push("version");
+  if (!manifest.manifestVersion) missing.push("manifestVersion");
+  if (!manifest.name?.short) missing.push("name.short");
+  if (!manifest.description?.short) missing.push("description.short");
+  if (!manifest.developer?.name) missing.push("developer.name");
+  if (!manifest.developer?.websiteUrl) missing.push("developer.websiteUrl");
+  if (!manifest.developer?.privacyUrl) missing.push("developer.privacyUrl");
+  if (!manifest.developer?.termsOfUseUrl) missing.push("developer.termsOfUseUrl");
+
+  if (missing.length > 0) {
+    if (silent) {
+      throw new CliError(
+        "VALIDATION_FORMAT",
+        `Manifest is missing required fields: ${missing.join(", ")}`,
+        "See https://learn.microsoft.com/en-us/microsoftteams/platform/resources/schema/manifest-schema for the full schema.",
+      );
+    }
+    logger.warn(pc.yellow(`Manifest is missing fields: ${missing.join(", ")}`));
+    if (!isAutoConfirm()) {
+      const proceed = await confirm({ message: "Upload anyway?", default: false });
+      if (!proceed) return;
+    }
   }
 
   const spinner = createSilentSpinner("Uploading manifest...", silent).start();

--- a/src/commands/app/manifest/index.ts
+++ b/src/commands/app/manifest/index.ts
@@ -4,6 +4,7 @@ import { fetchApp } from "../../../apps/index.js";
 import { pickApp } from "../../../utils/app-picker.js";
 import { isInteractive } from "../../../utils/interactive.js";
 import { downloadManifest, uploadManifestFromFile } from "./actions.js";
+import { CliError } from "../../../utils/errors.js";
 import { logger } from "../../../utils/logger.js";
 import { manifestDownloadCommand } from "./download.js";
 import { manifestUploadCommand } from "./upload.js";
@@ -43,6 +44,9 @@ export const appManifestCommand = new Command("manifest")
             await downloadManifest(picked.token, app.appId, savePath || undefined);
           } catch (error) {
             logger.error(pc.red(error instanceof Error ? error.message : "Unknown error"));
+            if (error instanceof CliError && error.suggestion) {
+              logger.error(error.suggestion);
+            }
           }
         }
 
@@ -62,6 +66,9 @@ export const appManifestCommand = new Command("manifest")
             await uploadManifestFromFile(picked.token, picked.app.teamsAppId, filePath);
           } catch (error) {
             logger.error(pc.red(error instanceof Error ? error.message : "Unknown error"));
+            if (error instanceof CliError && error.suggestion) {
+              logger.error(error.suggestion);
+            }
           }
         }
       } catch (error) {

--- a/src/commands/app/manifest/index.ts
+++ b/src/commands/app/manifest/index.ts
@@ -1,15 +1,16 @@
 import { Command } from "commander";
-import { input } from "@inquirer/prompts";
+import { input, select } from "@inquirer/prompts";
 import { fetchApp } from "../../../apps/index.js";
 import { pickApp } from "../../../utils/app-picker.js";
 import { isInteractive } from "../../../utils/interactive.js";
-import { downloadManifest } from "./actions.js";
+import { downloadManifest, uploadManifestFromFile } from "./actions.js";
 import { logger } from "../../../utils/logger.js";
 import { manifestDownloadCommand } from "./download.js";
+import { manifestUploadCommand } from "./upload.js";
 import pc from "picocolors";
 
 export const appManifestCommand = new Command("manifest")
-  .description("Download app manifests")
+  .description("Download or upload app manifests")
   .action(async function (this: Command) {
     if (!isInteractive()) {
       this.help();
@@ -18,18 +19,50 @@ export const appManifestCommand = new Command("manifest")
 
     while (true) {
       try {
-        const picked = await pickApp();
-        const app = await fetchApp(picked.token, picked.app.teamsAppId);
-
-        const savePath = await input({
-          message: `${app.appName ?? "Unnamed"} — save manifest to (leave empty to print):`,
-          default: "",
+        const action = await select({
+          message: "Manifest",
+          choices: [
+            { name: "Download", value: "download" },
+            { name: "Upload", value: "upload" },
+            { name: "Back", value: "back" },
+          ],
         });
 
-        try {
-          await downloadManifest(picked.token, app.appId, savePath || undefined);
-        } catch (error) {
-          logger.error(pc.red(error instanceof Error ? error.message : "Unknown error"));
+        if (action === "back") return;
+
+        if (action === "download") {
+          const picked = await pickApp();
+          const app = await fetchApp(picked.token, picked.app.teamsAppId);
+
+          const savePath = await input({
+            message: `${app.appName ?? "Unnamed"} — save manifest to (leave empty to print):`,
+            default: "",
+          });
+
+          try {
+            await downloadManifest(picked.token, app.appId, savePath || undefined);
+          } catch (error) {
+            logger.error(pc.red(error instanceof Error ? error.message : "Unknown error"));
+          }
+        }
+
+        if (action === "upload") {
+          const picked = await pickApp();
+
+          const filePath = await input({
+            message: "Path to manifest.json:",
+          });
+
+          if (!filePath) {
+            logger.error(pc.red("No file path provided."));
+            continue;
+          }
+
+          try {
+            await uploadManifestFromFile(picked.token, picked.app.teamsAppId, filePath);
+          } catch (error) {
+            logger.error(pc.red(error instanceof Error ? error.message : "Unknown error"));
+          }
         }
       } catch (error) {
         if (error instanceof Error && error.name === "ExitPromptError") {
@@ -41,3 +74,4 @@ export const appManifestCommand = new Command("manifest")
   });
 
 appManifestCommand.addCommand(manifestDownloadCommand);
+appManifestCommand.addCommand(manifestUploadCommand);

--- a/src/commands/app/manifest/upload.ts
+++ b/src/commands/app/manifest/upload.ts
@@ -1,0 +1,44 @@
+import { Command } from "commander";
+import { getAccount, getTokenSilent, teamsDevPortalScopes } from "../../../auth/index.js";
+import { pickApp } from "../../../utils/app-picker.js";
+import { CliError, wrapAction } from "../../../utils/errors.js";
+import { outputJson } from "../../../utils/json-output.js";
+import { uploadManifestFromFile } from "./actions.js";
+
+interface ManifestUploadOutput {
+  teamsAppId: string;
+  filePath: string;
+}
+
+export const manifestUploadCommand = new Command("upload")
+  .description("Upload a manifest.json to update an existing Teams app")
+  .argument("<file-path>", "Path to manifest.json file")
+  .argument("[appId]", "Teams app ID (prompted if not provided)")
+  .option("--json", "[OPTIONAL] Output result as JSON")
+  .action(wrapAction(async (filePathArg: string, appIdArg: string | undefined, options: { json?: boolean }) => {
+    let teamsAppId: string;
+    let token: string;
+
+    if (appIdArg) {
+      const account = await getAccount();
+      if (!account) {
+        throw new CliError("AUTH_REQUIRED", "Not logged in.", "Run `teams login` first.");
+      }
+
+      token = (await getTokenSilent(teamsDevPortalScopes))!;
+      if (!token) {
+        throw new CliError("AUTH_TOKEN_FAILED", "Failed to get token.", "Try `teams login` again.");
+      }
+      teamsAppId = appIdArg;
+    } else {
+      const picked = await pickApp();
+      teamsAppId = picked.app.teamsAppId;
+      token = picked.token;
+    }
+
+    await uploadManifestFromFile(token, teamsAppId, filePathArg);
+
+    if (options.json) {
+      outputJson({ teamsAppId, filePath: filePathArg } satisfies ManifestUploadOutput);
+    }
+  }));

--- a/src/commands/app/manifest/upload.ts
+++ b/src/commands/app/manifest/upload.ts
@@ -25,10 +25,11 @@ export const manifestUploadCommand = new Command("upload")
         throw new CliError("AUTH_REQUIRED", "Not logged in.", "Run `teams login` first.");
       }
 
-      token = (await getTokenSilent(teamsDevPortalScopes))!;
-      if (!token) {
+      const fetchedToken = await getTokenSilent(teamsDevPortalScopes);
+      if (!fetchedToken) {
         throw new CliError("AUTH_TOKEN_FAILED", "Failed to get token.", "Try `teams login` again.");
       }
+      token = fetchedToken;
       teamsAppId = appIdArg;
     } else if (options.json) {
       throw new CliError("VALIDATION_MISSING", "appId is required in --json mode.");

--- a/src/commands/app/manifest/upload.ts
+++ b/src/commands/app/manifest/upload.ts
@@ -14,7 +14,7 @@ export const manifestUploadCommand = new Command("upload")
   .description("Upload a manifest.json to update an existing Teams app")
   .argument("<file-path>", "Path to manifest.json file")
   .argument("[appId]", "Teams app ID (prompted if not provided)")
-  .option("--json", "[OPTIONAL] Output result as JSON")
+  .option("--json", "[OPTIONAL] Output as JSON")
   .action(wrapAction(async (filePathArg: string, appIdArg: string | undefined, options: { json?: boolean }) => {
     let teamsAppId: string;
     let token: string;

--- a/src/commands/app/manifest/upload.ts
+++ b/src/commands/app/manifest/upload.ts
@@ -30,13 +30,15 @@ export const manifestUploadCommand = new Command("upload")
         throw new CliError("AUTH_TOKEN_FAILED", "Failed to get token.", "Try `teams login` again.");
       }
       teamsAppId = appIdArg;
+    } else if (options.json) {
+      throw new CliError("VALIDATION_MISSING", "appId is required in --json mode.");
     } else {
       const picked = await pickApp();
       teamsAppId = picked.app.teamsAppId;
       token = picked.token;
     }
 
-    await uploadManifestFromFile(token, teamsAppId, filePathArg);
+    await uploadManifestFromFile(token, teamsAppId, filePathArg, options.json);
 
     if (options.json) {
       outputJson({ teamsAppId, filePath: filePathArg } satisfies ManifestUploadOutput);

--- a/tests/integration.test.ts
+++ b/tests/integration.test.ts
@@ -29,9 +29,9 @@ function run(command: string): { stdout: string; exitCode: number } {
     const stdout = execSync(command, { encoding: "utf-8", stdio: "pipe" });
     return { stdout, exitCode: 0 };
   } catch (error: unknown) {
-    const execError = error as { stdout?: string; status?: number };
+    const execError = error as { stdout?: string; stderr?: string; status?: number };
     return {
-      stdout: execError.stdout ?? "",
+      stdout: (execError.stdout ?? "") + (execError.stderr ?? ""),
       exitCode: execError.status ?? 1,
     };
   }

--- a/tests/menu-loop.test.ts
+++ b/tests/menu-loop.test.ts
@@ -332,6 +332,85 @@ describe("oauth menu loop", () => {
   });
 });
 
+describe("manifest menu loop", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    setupMocks();
+
+    vi.mock("../src/utils/app-picker.js", () => ({
+      pickApp: vi.fn().mockResolvedValue({
+        app: { appId: "test-app-id", teamsAppId: "test-teams-app-id" },
+        token: "test-token",
+      }),
+    }));
+
+    vi.mock("../src/apps/index.js", () => ({
+      fetchApp: vi.fn().mockResolvedValue({
+        appId: "test-app-id",
+        appName: "Test App",
+      }),
+    }));
+
+    vi.mock("../src/commands/app/manifest/actions.js", () => ({
+      downloadManifest: vi.fn().mockResolvedValue(undefined),
+      uploadManifestFromFile: vi.fn().mockResolvedValue(undefined),
+    }));
+  });
+
+  it("loops back to menu after selecting Download", async () => {
+    const { select, input } = await import("@inquirer/prompts");
+    const mockedSelect = vi.mocked(select);
+    const mockedInput = vi.mocked(input);
+
+    mockedSelect
+      .mockResolvedValueOnce("download" as never)
+      .mockResolvedValueOnce("back" as never);
+    mockedInput.mockResolvedValueOnce("" as never);
+
+    const { appManifestCommand } = await import(
+      "../src/commands/app/manifest/index.js"
+    );
+
+    await appManifestCommand.parseAsync([], { from: "user" });
+
+    expect(mockedSelect).toHaveBeenCalledTimes(2);
+  });
+
+  it("loops back to menu after selecting Upload", async () => {
+    const { select, input } = await import("@inquirer/prompts");
+    const mockedSelect = vi.mocked(select);
+    const mockedInput = vi.mocked(input);
+
+    mockedSelect
+      .mockResolvedValueOnce("upload" as never)
+      .mockResolvedValueOnce("back" as never);
+    mockedInput.mockResolvedValueOnce("./manifest.json" as never);
+
+    const { appManifestCommand } = await import(
+      "../src/commands/app/manifest/index.js"
+    );
+
+    await appManifestCommand.parseAsync([], { from: "user" });
+
+    expect(mockedSelect).toHaveBeenCalledTimes(2);
+  });
+
+  it("exits immediately when Back is selected", async () => {
+    const { select } = await import("@inquirer/prompts");
+    const mockedSelect = vi.mocked(select);
+    mockedSelect.mockResolvedValueOnce("back" as never);
+
+    const { appManifestCommand } = await import(
+      "../src/commands/app/manifest/index.js"
+    );
+
+    await appManifestCommand.parseAsync([], { from: "user" });
+
+    expect(mockedSelect).toHaveBeenCalledTimes(1);
+  });
+});
+
 describe("sso menu loop", () => {
   beforeEach(() => {
     vi.resetModules();


### PR DESCRIPTION
## Summary
- Adds `teams app manifest upload <file-path> [appId]` CLI subcommand that reads a local manifest.json, validates it, and uploads it to an existing Teams app via the TDP API (reuses existing `uploadManifest()`)
- Restructures the interactive manifest menu from direct-download to a select menu with Download / Upload / Back options
- Adds `--json` support with typed `ManifestUploadOutput` interface
- Adds 3 menu-loop tests for the new manifest menu

## Test plan
- [ ] `pnpm build` passes
- [ ] `pnpm test` — all unit tests pass (17 menu-loop + JSON flag tests)
- [ ] `node dist/index.js app manifest --help` shows both download and upload subcommands
- [ ] `node dist/index.js app manifest upload --help` shows correct usage
- [ ] `node dist/index.js app manifest` — interactive menu shows Download / Upload / Back
- [ ] `node dist/index.js app manifest upload ./manifest.json <appId>` — uploads manifest to app

🤖 Generated with [Claude Code](https://claude.com/claude-code)