### PR TITLE
feat: add --help --json for machine-readable command discovery

### DIFF
--- a/agentic-tests.md
+++ b/agentic-tests.md
@@ -19,3 +19,9 @@ node dist/index.js <command>
 **Setup:** `pnpm build` and be logged in
 **Act:** Run `node dist/index.js apps`
 **Assert:** Outputs a list of apps (may be empty list, but should not error).
+
+## 3. `--help --json` outputs machine-readable command tree
+
+**Setup:** `pnpm build`
+**Act:** Run `node dist/index.js --help --json`
+**Assert:** Outputs valid JSON with `name` ("teams"), `version`, and a non-empty `commands` array. No non-JSON text in output.

--- a/docs/commands/index.md
+++ b/docs/commands/index.md
@@ -57,6 +57,16 @@ teams
 └── self-update                    Update to latest version
 ```
 
+## Machine-Readable Help
+
+Use `--help --json` on any command to get the command tree as structured JSON — useful for AI agents and tooling that need to discover CLI capabilities programmatically:
+
+```bash
+teams --help --json          # Full command tree with version
+teams app --help --json      # Subtree for 'app'
+teams app rsc --help --json  # Subtree for 'app rsc'
+```
+
 ## Interactive vs Scripted
 
 Most commands work in two modes:

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,7 @@ import { selfUpdateCommand } from "./commands/self-update.js";
 import { configCommand } from "./commands/config/index.js";
 import { projectCommand } from "./commands/project/index.js";
 import { CliError } from "./utils/errors.js";
+import { handleJsonHelp } from "./utils/json-help.js";
 import { logger, setVerbose } from "./utils/logger.js";
 import { isInteractive, setAutoConfirm } from "./utils/interactive.js";
 import { checkForUpdates } from "./utils/update-check.js";
@@ -79,4 +80,6 @@ const newRedirect = new Command("new")
   });
 program.addCommand(newRedirect);
 
-program.parse();
+if (!handleJsonHelp(program, version)) {
+  program.parse();
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -37,7 +37,8 @@ function teamsColor(text: string): string {
 
 program
   .name("teams")
-  .addHelpText("beforeAll", `${pc.bold(teamsColor("Teams CLI"))} ${pc.bold(pc.yellow("[Beta]"))}\nWork seamlessly with Teams apps from the command line.\n`)
+  .description("CLI for managing Microsoft Teams apps")
+  .addHelpText("beforeAll", `${pc.bold(teamsColor("Teams CLI"))} ${pc.bold(pc.yellow("[Beta]"))}\n`)
   .version(version)
   .option("-v, --verbose", "[OPTIONAL] Enable verbose logging")
   .option("-y, --yes", "[OPTIONAL] Auto-confirm prompts (for CI/agent use)")

--- a/src/utils/json-help.ts
+++ b/src/utils/json-help.ts
@@ -10,7 +10,6 @@ export interface JsonHelpOption {
   optional: boolean;
   mandatory: boolean;
   variadic: boolean;
-  hidden: boolean;
   defaultValue?: string;
   choices?: string[];
 }
@@ -47,7 +46,6 @@ function serializeOption(opt: Option): JsonHelpOption {
     optional: opt.optional,
     mandatory: opt.mandatory,
     variadic: opt.variadic,
-    hidden: opt.hidden,
     ...(opt.defaultValue != null ? { defaultValue: String(opt.defaultValue) } : {}),
     ...(opt.argChoices ? { choices: opt.argChoices } : {}),
   };

--- a/src/utils/json-help.ts
+++ b/src/utils/json-help.ts
@@ -1,3 +1,4 @@
+import type { Argument, Option } from "commander";
 import { Command, Help } from "commander";
 import { outputJson } from "./json-output.js";
 
@@ -7,6 +8,7 @@ export interface JsonHelpOption {
   description: string;
   required: boolean;
   optional: boolean;
+  mandatory: boolean;
   variadic: boolean;
   hidden: boolean;
   defaultValue?: string;
@@ -37,12 +39,13 @@ export interface JsonHelpOutput extends JsonHelpCommand {
   version: string;
 }
 
-function serializeOption(opt: InstanceType<typeof import("commander").Option>): JsonHelpOption {
+function serializeOption(opt: Option): JsonHelpOption {
   return {
     flags: opt.flags,
     description: opt.description,
     required: opt.required,
     optional: opt.optional,
+    mandatory: opt.mandatory,
     variadic: opt.variadic,
     hidden: opt.hidden,
     ...(opt.defaultValue != null ? { defaultValue: String(opt.defaultValue) } : {}),
@@ -50,9 +53,7 @@ function serializeOption(opt: InstanceType<typeof import("commander").Option>): 
   };
 }
 
-function serializeArgument(
-  arg: InstanceType<typeof import("commander").Argument>,
-): JsonHelpArgument {
+function serializeArgument(arg: Argument): JsonHelpArgument {
   return {
     name: arg.name(),
     description: arg.description,

--- a/src/utils/json-help.ts
+++ b/src/utils/json-help.ts
@@ -6,10 +6,10 @@ import { outputJson } from "./json-output.js";
 export interface JsonHelpOption {
   flags: string;
   description: string;
-  required: boolean;
-  optional: boolean;
-  mandatory: boolean;
-  variadic: boolean;
+  required?: boolean;
+  optional?: boolean;
+  mandatory?: boolean;
+  variadic?: boolean;
   defaultValue?: string;
   choices?: string[];
 }
@@ -18,8 +18,8 @@ export interface JsonHelpOption {
 export interface JsonHelpArgument {
   name: string;
   description: string;
-  required: boolean;
-  variadic: boolean;
+  required?: boolean;
+  variadic?: boolean;
   defaultValue?: string;
   choices?: string[];
 }
@@ -42,10 +42,10 @@ function serializeOption(opt: Option): JsonHelpOption {
   return {
     flags: opt.flags,
     description: opt.description,
-    required: opt.required,
-    optional: opt.optional,
-    mandatory: opt.mandatory,
-    variadic: opt.variadic,
+    ...(opt.required ? { required: true } : {}),
+    ...(opt.optional ? { optional: true } : {}),
+    ...(opt.mandatory ? { mandatory: true } : {}),
+    ...(opt.variadic ? { variadic: true } : {}),
     ...(opt.defaultValue != null ? { defaultValue: String(opt.defaultValue) } : {}),
     ...(opt.argChoices ? { choices: opt.argChoices } : {}),
   };
@@ -55,8 +55,8 @@ function serializeArgument(arg: Argument): JsonHelpArgument {
   return {
     name: arg.name(),
     description: arg.description,
-    required: arg.required,
-    variadic: arg.variadic,
+    ...(arg.required ? { required: true } : {}),
+    ...(arg.variadic ? { variadic: true } : {}),
     ...(arg.defaultValue != null ? { defaultValue: String(arg.defaultValue) } : {}),
     ...(arg.argChoices ? { choices: arg.argChoices } : {}),
   };

--- a/src/utils/json-help.ts
+++ b/src/utils/json-help.ts
@@ -1,0 +1,130 @@
+import { Command, Help } from "commander";
+import { outputJson } from "./json-output.js";
+
+/** A single CLI option (flag) in JSON help output. */
+export interface JsonHelpOption {
+  flags: string;
+  description: string;
+  required: boolean;
+  optional: boolean;
+  variadic: boolean;
+  hidden: boolean;
+  defaultValue?: string;
+  choices?: string[];
+}
+
+/** A single CLI positional argument in JSON help output. */
+export interface JsonHelpArgument {
+  name: string;
+  description: string;
+  required: boolean;
+  variadic: boolean;
+  defaultValue?: string;
+  choices?: string[];
+}
+
+/** A command node in the JSON help tree. */
+export interface JsonHelpCommand {
+  name: string;
+  description: string;
+  options: JsonHelpOption[];
+  arguments: JsonHelpArgument[];
+  commands: JsonHelpCommand[];
+}
+
+/** Root-level JSON help output — includes version. */
+export interface JsonHelpOutput extends JsonHelpCommand {
+  version: string;
+}
+
+function serializeOption(opt: InstanceType<typeof import("commander").Option>): JsonHelpOption {
+  return {
+    flags: opt.flags,
+    description: opt.description,
+    required: opt.required,
+    optional: opt.optional,
+    variadic: opt.variadic,
+    hidden: opt.hidden,
+    ...(opt.defaultValue != null ? { defaultValue: String(opt.defaultValue) } : {}),
+    ...(opt.argChoices ? { choices: opt.argChoices } : {}),
+  };
+}
+
+function serializeArgument(
+  arg: InstanceType<typeof import("commander").Argument>,
+): JsonHelpArgument {
+  return {
+    name: arg.name(),
+    description: arg.description,
+    required: arg.required,
+    variadic: arg.variadic,
+    ...(arg.defaultValue != null ? { defaultValue: String(arg.defaultValue) } : {}),
+    ...(arg.argChoices ? { choices: arg.argChoices } : {}),
+  };
+}
+
+/**
+ * Serialize a Commander command (and its subtree) to a plain JSON object.
+ * Uses Commander's Help class to get visible items (filters hidden commands/options).
+ */
+export function serializeCommand(cmd: Command): JsonHelpCommand {
+  const helper = new Help();
+  const visibleOpts = helper
+    .visibleOptions(cmd)
+    .filter((opt) => opt.long !== "--help" && opt.long !== "--version");
+  const visibleArgs = helper.visibleArguments(cmd);
+  const visibleCmds = helper
+    .visibleCommands(cmd)
+    .filter((sub) => sub.name() !== "help");
+
+  return {
+    name: cmd.name(),
+    description: cmd.description(),
+    options: visibleOpts.map(serializeOption),
+    arguments: visibleArgs.map(serializeArgument),
+    commands: visibleCmds.map((sub) => serializeCommand(sub)),
+  };
+}
+
+/** Serialize the root program, including the CLI version. */
+export function serializeCommandTree(
+  cmd: Command,
+  version: string,
+): JsonHelpOutput {
+  return { ...serializeCommand(cmd), version };
+}
+
+/** Walk the command tree to find the target command from a list of names. */
+function resolveCommand(cmd: Command, args: string[]): Command {
+  if (args.length === 0) return cmd;
+  const sub = cmd.commands.find(
+    (c) => c.name() === args[0] || c.aliases().includes(args[0]),
+  );
+  if (!sub) return cmd;
+  return resolveCommand(sub, args.slice(1));
+}
+
+/**
+ * If `--help` and `--json` both appear in argv, output the command tree
+ * as JSON. Returns true if handled (caller should skip `program.parse()`).
+ * Must be called BEFORE `program.parse()`.
+ */
+export function handleJsonHelp(prog: Command, version: string): boolean {
+  const argv = process.argv.slice(2);
+  const hasHelp = argv.includes("--help") || argv.includes("-h");
+  const hasJson = argv.includes("--json");
+
+  if (!hasHelp || !hasJson) return false;
+
+  const commandPath = argv.filter((a) => !a.startsWith("-"));
+  const target = resolveCommand(prog, commandPath);
+  const isRoot = target === prog;
+
+  if (isRoot) {
+    outputJson(serializeCommandTree(target, version));
+  } else {
+    outputJson(serializeCommand(target));
+  }
+
+  return true;
+}

--- a/src/utils/json-help.ts
+++ b/src/utils/json-help.ts
@@ -6,8 +6,9 @@ import { outputJson } from "./json-output.js";
 export interface JsonHelpOption {
   flags: string;
   description: string;
-  required?: boolean;
-  optional?: boolean;
+  /** If true, a value must be provided when this flag is used (e.g. --name <name>). */
+  requiredIfProvided?: boolean;
+  /** Whether this flag must be specified. Always present when requiredIfProvided is set. */
   mandatory?: boolean;
   variadic?: boolean;
   defaultValue?: string;
@@ -42,9 +43,10 @@ function serializeOption(opt: Option): JsonHelpOption {
   return {
     flags: opt.flags,
     description: opt.description,
-    ...(opt.required ? { required: true } : {}),
-    ...(opt.optional ? { optional: true } : {}),
-    ...(opt.mandatory ? { mandatory: true } : {}),
+    ...(opt.required
+      ? { requiredIfProvided: true, mandatory: opt.mandatory }
+      : {}),
+    ...(!opt.required && opt.mandatory ? { mandatory: true } : {}),
     ...(opt.variadic ? { variadic: true } : {}),
     ...(opt.defaultValue != null ? { defaultValue: String(opt.defaultValue) } : {}),
     ...(opt.argChoices ? { choices: opt.argChoices } : {}),

--- a/tests/json-help.test.ts
+++ b/tests/json-help.test.ts
@@ -1,7 +1,3 @@
-// RED/GREEN: verified 2026-04-13
-// RED: commented out handleJsonHelp call in index.ts → --help --json produced Commander text help, JSON.parse threw
-// GREEN: restored handleJsonHelp call → all tests pass
-
 import { describe, it, expect } from "vitest";
 import { Command, Option } from "commander";
 import { execSync } from "node:child_process";

--- a/tests/json-help.test.ts
+++ b/tests/json-help.test.ts
@@ -1,0 +1,220 @@
+// RED/GREEN: verified 2026-04-13
+// RED: commented out handleJsonHelp call in index.ts → --help --json produced Commander text help, JSON.parse threw
+// GREEN: restored handleJsonHelp call → all tests pass
+
+import { describe, it, expect } from "vitest";
+import { Command, Option } from "commander";
+import { execSync } from "node:child_process";
+import {
+  serializeCommand,
+  serializeCommandTree,
+} from "../src/utils/json-help.js";
+
+const CLI = "node dist/index.js";
+
+function run(command: string): { stdout: string; exitCode: number } {
+  try {
+    const stdout = execSync(command, { encoding: "utf-8", stdio: "pipe" });
+    return { stdout, exitCode: 0 };
+  } catch (error: unknown) {
+    const execError = error as {
+      stdout?: string;
+      stderr?: string;
+      status?: number;
+    };
+    return {
+      stdout: (execError.stdout ?? "") + (execError.stderr ?? ""),
+      exitCode: execError.status ?? 1,
+    };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Unit tests — serializeCommand / serializeCommandTree
+// ---------------------------------------------------------------------------
+describe("serializeCommand", () => {
+  it("serializes a leaf command with options and arguments", () => {
+    const cmd = new Command("list")
+      .description("List items")
+      .argument("<appId>", "App ID")
+      .option("--json", "[OPTIONAL] Output as JSON");
+
+    const result = serializeCommand(cmd);
+
+    expect(result.name).toBe("list");
+    expect(result.description).toBe("List items");
+    expect(result.arguments).toHaveLength(1);
+    expect(result.arguments[0].name).toBe("appId");
+    expect(result.arguments[0].required).toBe(true);
+    expect(result.options).toHaveLength(1);
+    expect(result.options[0].flags).toBe("--json");
+    expect(result.commands).toEqual([]);
+  });
+
+  it("serializes nested commands recursively", () => {
+    const parent = new Command("app").description("Manage apps");
+    const child = new Command("create").description("Create app");
+    parent.addCommand(child);
+
+    const result = serializeCommand(parent);
+
+    expect(result.commands).toHaveLength(1);
+    expect(result.commands[0].name).toBe("create");
+    expect(result.commands[0].description).toBe("Create app");
+  });
+
+  it("filters out --help and --version options", () => {
+    const cmd = new Command("test")
+      .description("Test")
+      .version("1.0.0")
+      .option("--json", "JSON output");
+
+    const result = serializeCommand(cmd);
+
+    const flags = result.options.map((o) => o.flags);
+    expect(flags).not.toContain("--help");
+    expect(flags).not.toContain("-h, --help");
+    expect(flags).not.toContain("-V, --version");
+    expect(result.options).toHaveLength(1);
+    expect(result.options[0].flags).toBe("--json");
+  });
+
+  it("serializes optional arguments correctly", () => {
+    const cmd = new Command("view")
+      .description("View")
+      .argument("[appId]", "Optional app ID");
+
+    const result = serializeCommand(cmd);
+
+    expect(result.arguments[0].required).toBe(false);
+  });
+
+  it("includes default values when present", () => {
+    const cmd = new Command("run")
+      .description("Run")
+      .option("--port <port>", "Port number", "3000");
+
+    const result = serializeCommand(cmd);
+
+    expect(result.options[0].defaultValue).toBe("3000");
+  });
+
+  it("omits defaultValue when not present", () => {
+    const cmd = new Command("run")
+      .description("Run")
+      .option("--name <name>", "Name");
+
+    const result = serializeCommand(cmd);
+
+    expect(result.options[0]).not.toHaveProperty("defaultValue");
+  });
+
+  it("includes choices when present", () => {
+    const cmd = new Command("add").description("Add");
+    cmd.addOption(
+      new Option("--type <type>", "Type").choices([
+        "Application",
+        "Delegated",
+      ]),
+    );
+
+    const result = serializeCommand(cmd);
+
+    expect(result.options[0].choices).toEqual(["Application", "Delegated"]);
+  });
+});
+
+describe("serializeCommandTree", () => {
+  it("includes version on root output", () => {
+    const cmd = new Command("teams").description("CLI");
+    const result = serializeCommandTree(cmd, "2.0.0");
+
+    expect(result.version).toBe("2.0.0");
+    expect(result.name).toBe("teams");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Integration tests — actual CLI invocation
+// ---------------------------------------------------------------------------
+describe("--help --json CLI integration", () => {
+  it("outputs valid JSON for root help", () => {
+    const { stdout, exitCode } = run(`${CLI} --help --json`);
+    const data = JSON.parse(stdout);
+
+    expect(exitCode).toBe(0);
+    expect(data.name).toBe("teams");
+    expect(data.version).toBeDefined();
+    expect(data.commands).toBeInstanceOf(Array);
+    expect(data.commands.length).toBeGreaterThan(0);
+  });
+
+  it("includes expected top-level commands", () => {
+    const { stdout } = run(`${CLI} --help --json`);
+    const data = JSON.parse(stdout);
+    const names = data.commands.map((c: { name: string }) => c.name);
+
+    expect(names).toContain("login");
+    expect(names).toContain("app");
+    expect(names).toContain("status");
+  });
+
+  it("outputs subtree for app command", () => {
+    const { stdout, exitCode } = run(`${CLI} app --help --json`);
+    const data = JSON.parse(stdout);
+
+    expect(exitCode).toBe(0);
+    expect(data.name).toBe("app");
+    expect(data.commands.length).toBeGreaterThan(0);
+
+    const listCmd = data.commands.find(
+      (c: { name: string }) => c.name === "list",
+    );
+    expect(listCmd).toBeDefined();
+  });
+
+  it("outputs leaf command details", () => {
+    const { stdout, exitCode } = run(`${CLI} app list --help --json`);
+    const data = JSON.parse(stdout);
+
+    expect(exitCode).toBe(0);
+    expect(data.name).toBe("list");
+    expect(data.commands).toEqual([]);
+    const jsonOpt = data.options.find((o: { flags: string }) =>
+      o.flags.includes("--json"),
+    );
+    expect(jsonOpt).toBeDefined();
+  });
+
+  it("does not include version on non-root commands", () => {
+    const { stdout } = run(`${CLI} app --help --json`);
+    const data = JSON.parse(stdout);
+
+    expect(data.version).toBeUndefined();
+  });
+
+  it("produces no non-JSON output", () => {
+    const { stdout } = run(`${CLI} --help --json`);
+    // stdout should be valid JSON with no extra text
+    expect(() => JSON.parse(stdout)).not.toThrow();
+    const parsed = JSON.parse(stdout);
+    expect(stdout.trim()).toBe(JSON.stringify(parsed, null, 2));
+  });
+
+  it("works with flags in different order", () => {
+    const { stdout, exitCode } = run(`${CLI} --json app --help`);
+    const data = JSON.parse(stdout);
+
+    expect(exitCode).toBe(0);
+    expect(data.name).toBe("app");
+  });
+
+  it("works with -h shorthand", () => {
+    const { stdout, exitCode } = run(`${CLI} -h --json`);
+    const data = JSON.parse(stdout);
+
+    expect(exitCode).toBe(0);
+    expect(data.name).toBe("teams");
+    expect(data.version).toBeDefined();
+  });
+});

--- a/tests/json-help.test.ts
+++ b/tests/json-help.test.ts
@@ -122,6 +122,26 @@ describe("serializeCommand", () => {
 
     expect(result.options[0].choices).toEqual(["Application", "Delegated"]);
   });
+
+  it("distinguishes mandatory options from options with required values", () => {
+    const cmd = new Command("add")
+      .description("Add")
+      .requiredOption("--type <type>", "Permission type")
+      .option("--name <name>", "Optional name with required value");
+
+    const result = serializeCommand(cmd);
+
+    const typeOpt = result.options.find((o) => o.flags.includes("--type"));
+    const nameOpt = result.options.find((o) => o.flags.includes("--name"));
+
+    // --type is mandatory (must be provided) AND has a required value
+    expect(typeOpt!.mandatory).toBe(true);
+    expect(typeOpt!.required).toBe(true);
+
+    // --name is not mandatory but has a required value
+    expect(nameOpt!.mandatory).toBe(false);
+    expect(nameOpt!.required).toBe(true);
+  });
 });
 
 describe("serializeCommandTree", () => {

--- a/tests/json-help.test.ts
+++ b/tests/json-help.test.ts
@@ -86,7 +86,17 @@ describe("serializeCommand", () => {
 
     const result = serializeCommand(cmd);
 
-    expect(result.arguments[0].required).toBe(false);
+    expect(result.arguments[0].required).toBeUndefined();
+  });
+
+  it("serializes required arguments correctly", () => {
+    const cmd = new Command("view")
+      .description("View")
+      .argument("<appId>", "App ID");
+
+    const result = serializeCommand(cmd);
+
+    expect(result.arguments[0].required).toBe(true);
   });
 
   it("includes default values when present", () => {
@@ -139,8 +149,24 @@ describe("serializeCommand", () => {
     expect(typeOpt!.required).toBe(true);
 
     // --name is not mandatory but has a required value
-    expect(nameOpt!.mandatory).toBe(false);
+    expect(nameOpt!.mandatory).toBeUndefined();
     expect(nameOpt!.required).toBe(true);
+  });
+
+  it("omits false boolean fields for clean output", () => {
+    const cmd = new Command("run")
+      .description("Run")
+      .option("--json", "[OPTIONAL] Output as JSON");
+
+    const result = serializeCommand(cmd);
+    const jsonOpt = result.options[0];
+
+    // Boolean flag: no required/optional/mandatory/variadic
+    expect(jsonOpt.flags).toBe("--json");
+    expect(jsonOpt.required).toBeUndefined();
+    expect(jsonOpt.optional).toBeUndefined();
+    expect(jsonOpt.mandatory).toBeUndefined();
+    expect(jsonOpt.variadic).toBeUndefined();
   });
 });
 

--- a/tests/json-help.test.ts
+++ b/tests/json-help.test.ts
@@ -140,16 +140,16 @@ describe("serializeCommand", () => {
     const typeOpt = result.options.find((o) => o.flags.includes("--type"));
     const nameOpt = result.options.find((o) => o.flags.includes("--name"));
 
-    // --type is mandatory (must be provided) AND has a required value
+    // --type: must be provided, and needs a value
+    expect(typeOpt!.requiredIfProvided).toBe(true);
     expect(typeOpt!.mandatory).toBe(true);
-    expect(typeOpt!.required).toBe(true);
 
-    // --name is not mandatory but has a required value
-    expect(nameOpt!.mandatory).toBeUndefined();
-    expect(nameOpt!.required).toBe(true);
+    // --name: optional flag, but needs a value if used
+    expect(nameOpt!.requiredIfProvided).toBe(true);
+    expect(nameOpt!.mandatory).toBe(false);
   });
 
-  it("omits false boolean fields for clean output", () => {
+  it("omits value fields for boolean flags", () => {
     const cmd = new Command("run")
       .description("Run")
       .option("--json", "[OPTIONAL] Output as JSON");
@@ -157,10 +157,9 @@ describe("serializeCommand", () => {
     const result = serializeCommand(cmd);
     const jsonOpt = result.options[0];
 
-    // Boolean flag: no required/optional/mandatory/variadic
+    // Boolean flag: no requiredIfProvided/mandatory/variadic
     expect(jsonOpt.flags).toBe("--json");
-    expect(jsonOpt.required).toBeUndefined();
-    expect(jsonOpt.optional).toBeUndefined();
+    expect(jsonOpt.requiredIfProvided).toBeUndefined();
     expect(jsonOpt.mandatory).toBeUndefined();
     expect(jsonOpt.variadic).toBeUndefined();
   });


### PR DESCRIPTION
## Summary
- Adds `--help --json` flag combination that outputs the full command tree as structured JSON, enabling AI agents to programmatically discover CLI capabilities (closes #83)
- Intercepts argv before `program.parse()` — uses Commander's `Help` class (`visibleCommands`, `visibleOptions`, `visibleArguments`) to recursively serialize the tree
- Works at any level: `teams --help --json` (full tree with version), `teams app --help --json` (subtree), `teams app rsc add --help --json` (leaf)

## Test plan
- [x] Unit tests for `serializeCommand` / `serializeCommandTree` with synthetic Commander commands
- [x] Integration tests via `execSync` — root, subtree, leaf, flag ordering, `-h` shorthand
- [x] `pnpm build` compiles cleanly
- [x] `pnpm test` — all 60 tests pass
- [x] Agentic test #3 added and verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)