### PR TITLE
Remove auto-update, replace with manual update warning

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -41,7 +41,6 @@ program
   .version(version)
   .option("-v, --verbose", "[OPTIONAL] Enable verbose logging")
   .option("-y, --yes", "[OPTIONAL] Auto-confirm prompts (for CI/agent use)")
-  .option("--disable-auto-update", "[OPTIONAL] Disable automatic updates")
   .addHelpText("after", () => {
     const status = isInteractive() ? pc.green("on") : pc.yellow("off");
     return `\nInteractive mode: ${status}\n  Set ${pc.cyan("TEAMS_NO_INTERACTIVE=1")} to disable, unset to enable.`;
@@ -55,7 +54,7 @@ program
       setAutoConfirm(true);
     }
     if (actionCommand.name() !== "self-update") {
-      await checkForUpdates({ autoUpdate: !opts.disableAutoUpdate });
+      await checkForUpdates();
     }
   });
 

--- a/src/utils/update-check.ts
+++ b/src/utils/update-check.ts
@@ -1,11 +1,9 @@
 import { readFile, writeFile, mkdir } from "node:fs/promises";
 import { join } from "node:path";
 import { createRequire } from "node:module";
-import { spawn } from "node:child_process";
 import pc from "picocolors";
 import { paths } from "../auth/config.js";
 import { isInteractive } from "./interactive.js";
-import { runSelfUpdate } from "../commands/self-update.js";
 import { logger } from "./logger.js";
 
 const STATE_FILE = join(paths.cache, "update-check.json");
@@ -51,29 +49,22 @@ async function fetchLatestVersion(): Promise<string | null> {
 }
 
 /**
- * Check for updates once daily. Auto-updates and re-runs the command by default.
- * Pass autoUpdate: false to just show a hint instead.
+ * Check for updates once daily and show a warning if a newer version is available.
  * Non-blocking — silently skips on any failure.
  */
-export async function checkForUpdates(options?: { autoUpdate?: boolean }): Promise<void> {
+export async function checkForUpdates(): Promise<void> {
   if (!isInteractive()) return;
   if (alreadyChecked) return;
   alreadyChecked = true;
-
-  const autoUpdate = options?.autoUpdate ?? true;
 
   try {
     const state = await readState();
     const now = Date.now();
 
     if (state && now - state.lastCheck < CHECK_INTERVAL_MS) {
-      // Already checked recently — auto-update or show hint if we cached a newer version
+      // Already checked recently — show hint if we cached a newer version
       if (state.latestVersion) {
-        if (autoUpdate) {
-          await autoUpdateAndRerun();
-        } else {
-          showUpdateHint(state.latestVersion);
-        }
+        showUpdateHint(state.latestVersion);
       }
       return;
     }
@@ -83,36 +74,13 @@ export async function checkForUpdates(options?: { autoUpdate?: boolean }): Promi
 
     if (latestVersion && isNewer(latestVersion)) {
       newState.latestVersion = latestVersion;
-
-      if (autoUpdate) {
-        await writeState(newState);
-        await autoUpdateAndRerun();
-      } else {
-        showUpdateHint(latestVersion);
-      }
+      showUpdateHint(latestVersion);
     }
 
     await writeState(newState);
   } catch {
     // Never block the CLI
   }
-}
-
-async function autoUpdateAndRerun(): Promise<void> {
-  const success = await runSelfUpdate();
-  if (success) {
-    // Re-run the original command using spawn with an argv array (no shell, no injection risk)
-    const filteredArgs = process.argv.slice(2).filter((a) => a !== "--disable-auto-update");
-    const [bin, spawnArgs] = process.argv[1]
-      ? [process.execPath, [process.argv[1], "--disable-auto-update", ...filteredArgs]]
-      : ["teams", ["--disable-auto-update", ...filteredArgs]];
-    await new Promise<void>((resolve) => {
-      const child = spawn(bin, spawnArgs, { stdio: "inherit", shell: false });
-      child.on("close", () => resolve());
-    });
-    process.exit(0);
-  }
-  // On failure, runSelfUpdate already printed the error — continue with current version
 }
 
 function showUpdateHint(latestVersion: string): void {


### PR DESCRIPTION
## Summary

- Removes automatic CLI updates that interrupted commands and re-executed them
- Replaces with a once-daily warning message prompting users to run `teams self-update`
- Simplifies update-check logic by removing auto-update code paths

## Changes

- **src/index.ts**: Removed `--disable-auto-update` flag and simplified `checkForUpdates()` call
- **src/utils/update-check.ts**: Removed `autoUpdateAndRerun()` function and all related auto-update logic

## Behavior

**Before:**
- CLI automatically downloaded and installed updates before running commands
- Command was re-executed after update
- Could be disabled with `--disable-auto-update` flag

**After:**
- CLI shows a warning once per day if an update is available:
  ```
  Update available: 1.0.0 → 1.0.1  Run teams self-update to update.
  ```
- Users must manually run `teams self-update` to update
- No interruption to normal command execution

## Test plan

- [x] `pnpm build` - compiles successfully
- [x] `tsc --noEmit` - type-checks successfully
- [x] `teams --help` - verify `--disable-auto-update` flag is removed
- [x] `teams --version` - basic command works
- [x] `teams status` - subcommands work correctly
- [x] `teams self-update --help` - manual update command still available

🤖 Generated with [Claude Code](https://claude.com/claude-code)