### PR TITLE
Add --json to global help output

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ teams self-update                    # Update to the latest version
 | Flag | Description |
 |------|-------------|
 | `-v, --verbose` | Enable verbose logging |
-| `--json` | Output results as JSON (machine-readable) |
+| `--json` | Output results as JSON (structured output, recommended for agents) |
 | `--yes` / `-y` | Skip confirmation prompts (CI/agent use) |
 | `--disable-auto-update` | Disable automatic update checks |
 

--- a/agentic-tests.md
+++ b/agentic-tests.md
@@ -20,7 +20,7 @@ node dist/index.js <command>
 **Act:** Run `node dist/index.js apps`
 **Assert:** Outputs a list of apps (may be empty list, but should not error).
 
-## 3. `--help --json` outputs machine-readable command tree
+## 3. `--help --json` outputs structured command tree
 
 **Setup:** `pnpm build`
 **Act:** Run `node dist/index.js --help --json`

--- a/docs/commands/index.md
+++ b/docs/commands/index.md
@@ -51,7 +51,7 @@ teams
 └── self-update                    Update to latest version
 ```
 
-## Machine-Readable Help
+## Structured Help
 
 Use `--help --json` on any command to get the command tree as structured JSON — useful for AI agents and tooling that need to discover CLI capabilities programmatically:
 
@@ -66,6 +66,6 @@ teams app rsc --help --json  # Subtree for 'app rsc'
 Most commands work in two modes:
 
 - **Interactive** — omit the `[appId]` argument and the CLI presents a searchable app picker. Subcommands like `app` and `app manifest` show action menus.
-- **Scripted** — pass `[appId]` and all required flags directly for CI/CD or automation. Use `--json` where available for machine-readable output.
+- **Scripted** — pass `[appId]` and all required flags directly for CI/CD or automation. Use `--json` where available for structured output.
 
 Set `TEAMS_NO_INTERACTIVE=1` to disable interactive prompts entirely.

--- a/src/index.ts
+++ b/src/index.ts
@@ -41,7 +41,7 @@ program
   .version(version)
   .option("-v, --verbose", "[OPTIONAL] Enable verbose logging")
   .option("-y, --yes", "[OPTIONAL] Auto-confirm prompts (for CI/agent use)")
-  .option("--json", "[OPTIONAL] Machine-readable JSON output")
+  .helpOption("-h, --help", "Display help (use with --json for structured output)")
   .addHelpText("after", () => {
     const status = isInteractive() ? pc.green("on") : pc.yellow("off");
     return `\nInteractive mode: ${status}\n  Set ${pc.cyan("TEAMS_NO_INTERACTIVE=1")} to disable, unset to enable.`;

--- a/src/index.ts
+++ b/src/index.ts
@@ -41,6 +41,7 @@ program
   .version(version)
   .option("-v, --verbose", "[OPTIONAL] Enable verbose logging")
   .option("-y, --yes", "[OPTIONAL] Auto-confirm prompts (for CI/agent use)")
+  .option("--json", "[OPTIONAL] Machine-readable JSON output")
   .addHelpText("after", () => {
     const status = isInteractive() ? pc.green("on") : pc.yellow("off");
     return `\nInteractive mode: ${status}\n  Set ${pc.cyan("TEAMS_NO_INTERACTIVE=1")} to disable, unset to enable.`;


### PR DESCRIPTION
## Summary
- Register `--json` as a visible global option so it appears in `teams --help`
- Previously the flag worked but was invisible in help output — agents couldn't discover it

## Test plan
- [ ] `teams --help` shows `--json` in the Options section
- [ ] `teams --help --json` still outputs the full command tree as JSON
- [ ] `teams app list --json` still works as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)