### PR TITLE
Show input summary before app creation confirmation

### DIFF
--- a/src/commands/app/create.ts
+++ b/src/commands/app/create.ts
@@ -191,9 +191,9 @@ export const appCreateCommand = new Command("create")
 			summaryLines.push(["Resource group", azureContext.resourceGroup]);
 		}
 		if (endpoint) summaryLines.push(["Endpoint", endpoint]);
-		if (descriptionOpts) summaryLines.push(["Description", descriptionOpts.short]);
-		if (scopeChoices) summaryLines.push(["Scopes", scopeChoices.join(", ")]);
-		if (developerOpts) summaryLines.push(["Developer", developerOpts.name]);
+		if (descriptionOpts?.short.trim()) summaryLines.push(["Description", descriptionOpts.short]);
+		if (scopeChoices && scopeChoices.length > 0) summaryLines.push(["Scopes", scopeChoices.join(", ")]);
+		if (developerOpts?.name.trim()) summaryLines.push(["Developer", developerOpts.name]);
 		if (colorIconPath) summaryLines.push(["Color icon", colorIconPath]);
 		if (outlineIconPath) summaryLines.push(["Outline icon", outlineIconPath]);
 		if (envPath) summaryLines.push([".env file", envPath]);

--- a/src/commands/app/create.ts
+++ b/src/commands/app/create.ts
@@ -191,14 +191,14 @@ export const appCreateCommand = new Command("create")
 			summaryLines.push(["Resource group", azureContext.resourceGroup]);
 		}
 		if (endpoint) summaryLines.push(["Endpoint", endpoint]);
-		if (descriptionOpts?.short.trim()) summaryLines.push(["Description", descriptionOpts.short]);
+		if (descriptionOpts?.short.trim()) summaryLines.push(["Description", descriptionOpts.short.trim()]);
 		if (scopeChoices && scopeChoices.length > 0) summaryLines.push(["Scopes", scopeChoices.join(", ")]);
-		if (developerOpts?.name.trim()) summaryLines.push(["Developer", developerOpts.name]);
+		if (developerOpts?.name.trim()) summaryLines.push(["Developer", developerOpts.name.trim()]);
 		if (colorIconPath) summaryLines.push(["Color icon", colorIconPath]);
 		if (outlineIconPath) summaryLines.push(["Outline icon", outlineIconPath]);
 		if (envPath) summaryLines.push([".env file", envPath]);
 
-		if (!silent) {
+		if (interactive && !silent) {
 			logger.info("");
 			for (const [label, value] of summaryLines) {
 				logger.info(`  ${pc.dim(`${label}:`)}  ${value}`);

--- a/src/commands/app/create.ts
+++ b/src/commands/app/create.ts
@@ -183,8 +183,30 @@ export const appCreateCommand = new Command("create")
 		const outlineIcon = outlineIconPath ? readAndValidateIcon(outlineIconPath, 32) : undefined;
 
 		// ===== All inputs gathered — confirm before proceeding =====
-		const locationLabel = location === "azure" ? "Azure" : "Teams-managed";
-		if (!await confirmAction(`Create Teams app "${name}" with ${locationLabel} bot?`, silent)) {
+		const summaryLines: [string, string][] = [
+			["App name", name],
+		];
+		if (azureContext) {
+			summaryLines.push(["Subscription", azureContext.subscription]);
+			summaryLines.push(["Resource group", azureContext.resourceGroup]);
+		}
+		if (endpoint) summaryLines.push(["Endpoint", endpoint]);
+		if (descriptionOpts) summaryLines.push(["Description", descriptionOpts.short]);
+		if (scopeChoices) summaryLines.push(["Scopes", scopeChoices.join(", ")]);
+		if (developerOpts) summaryLines.push(["Developer", developerOpts.name]);
+		if (colorIconPath) summaryLines.push(["Color icon", colorIconPath]);
+		if (outlineIconPath) summaryLines.push(["Outline icon", outlineIconPath]);
+		if (envPath) summaryLines.push([".env file", envPath]);
+
+		if (!silent) {
+			logger.info("");
+			for (const [label, value] of summaryLines) {
+				logger.info(`  ${pc.dim(`${label}:`)}  ${value}`);
+			}
+			logger.info("");
+		}
+
+		if (!await confirmAction("Confirm creation?", silent)) {
 			return;
 		}
 


### PR DESCRIPTION
## Summary
- Replace the single-line confirmation (`Create Teams app "X" with Teams-managed bot?`) with a full summary of all gathered inputs before confirming
- Shows: app name, endpoint, description, scopes, developer, color/outline icons, .env path
- Azure context (subscription, resource group) shown only when creating an Azure bot
- Fields without values are omitted

## Test plan
- [ ] Run `teams app create` interactively, fill out all fields — verify summary shows all inputs
- [ ] Run `teams app create --name "Test"` — verify only app name shown
- [ ] Run `teams app create --name "Test" --azure ...` — verify subscription/resource group appear
- [ ] Run `teams app create --json --name "Test"` — verify no summary output

🤖 Generated with [Claude Code](https://claude.com/claude-code)