### PR TITLE
Fix app get --json to return bot endpoint

### DIFF
--- a/src/commands/app/get.ts
+++ b/src/commands/app/get.ts
@@ -3,6 +3,7 @@ import pc from "picocolors";
 import { createSilentSpinner } from "../../utils/spinner.js";
 import { getAccount, getTokenSilent, teamsDevPortalScopes } from "../../auth/index.js";
 import { fetchApp, fetchAppDetailsV2, showAppDetail } from "../../apps/index.js";
+import { fetchBot } from "../../apps/tdp.js";
 import { outputJson } from "../../utils/json-output.js";
 import { pickApp } from "../../utils/app-picker.js";
 import { CliError, wrapAction } from "../../utils/errors.js";
@@ -65,6 +66,18 @@ export const appGetCommand = new Command("get")
     if (options.json) {
       const spinner = createSilentSpinner("Fetching app details...", true).start();
       const details = await fetchAppDetailsV2(token, app.teamsAppId);
+
+      // Fetch bot endpoint separately from the bot framework API
+      let endpoint: string | null = null;
+      if (details.bots && details.bots.length > 0) {
+        try {
+          const bot = await fetchBot(token, details.bots[0].botId);
+          endpoint = bot.messagingEndpoint || null;
+        } catch {
+          // Bot fetch failed, endpoint remains null
+        }
+      }
+
       spinner.stop();
 
       const enriched: AppGetOutput = {
@@ -79,7 +92,7 @@ export const appGetCommand = new Command("get")
         websiteUrl: details.websiteUrl,
         privacyUrl: details.privacyUrl,
         termsOfUseUrl: details.termsOfUseUrl,
-        endpoint: details.bots?.[0]?.messagingEndpoint ?? null,
+        endpoint: endpoint,
         installLink: `https://teams.microsoft.com/l/app/${details.teamsAppId}?installAppPackage=true`,
         portalLink: `https://dev.teams.microsoft.com/apps/${details.teamsAppId}`,
       };


### PR DESCRIPTION
## Summary
- Fixes `teams app get --json` to correctly return the bot messaging endpoint
- Previously returned `null` even when endpoint was set

## Problem
The `/appdefinitions/v2` API doesn't include `messagingEndpoint` in the bots array, so the JSON output was always showing `endpoint: null`.

## Solution
Fetch bot details separately from the `/botframework` API (same approach used in non-JSON mode) to get the actual messaging endpoint.

## Testing
Before:
```json
"endpoint": null
```

After:
```json
"endpoint": "https://3p8kf44q-3978.usw2.devtunnels.ms/api/messages22"
```

Tested with: `teams app get 48e4757c-a065-4fcf-99fd-c143bc9eeae1 --json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)